### PR TITLE
Added coproduct formats derived by Shapeless 

### DIFF
--- a/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/FlatTypeFormat.scala
+++ b/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/FlatTypeFormat.scala
@@ -1,0 +1,8 @@
+package com.evolutiongaming.util.generic
+
+import play.api.libs.json._
+
+object FlatTypeFormat {
+  def apply[A](implicit reads: FlatTypeReads[A], writes: FlatTypeWrites[A]): OFormat[A] =
+    OFormat(reads reads _, writes writes _)
+}

--- a/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/FlatTypeReads.scala
+++ b/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/FlatTypeReads.scala
@@ -1,0 +1,46 @@
+package com.evolutiongaming.util.generic
+
+import play.api.libs.json._
+import shapeless._
+import shapeless.labelled._
+
+trait FlatTypeReads[T] extends Reads[T] {
+  override def reads(jsValue: JsValue): JsResult[T]
+}
+
+object FlatTypeReads {
+
+  def apply[A](implicit decode: FlatTypeReads[A]): FlatTypeReads[A] = decode
+
+  def create[A](f: JsValue => JsResult[A]): FlatTypeReads[A] = new FlatTypeReads[A] {
+    override def reads(json: JsValue): JsResult[A] = f(json)
+  }
+
+  implicit def cnilReads: FlatTypeReads[CNil] = create[CNil] { _ =>
+    JsError("could not decode cnil")
+  }
+
+  implicit def cconsReads[Key <: Symbol, Head, Tail <: Coproduct](implicit
+      key: Witness.Aux[Key],
+      headReads: Reads[Head],
+      tailReads: FlatTypeReads[Tail]): FlatTypeReads[FieldType[Key, Head] :+: Tail] =
+    create[FieldType[Key, Head] :+: Tail] { json =>
+
+      for {
+        o <- json.validate[JsObject]
+        typ <- (o \ "type").validate[String]
+        res <- if (typ == key.value.name) {
+          headReads reads (o - "type") map { z => Inl(field[Key](z)) }
+        }
+        else {
+          tailReads reads o map { Inr(_) }
+        }
+      } yield res
+    }
+
+  implicit def flatTypeReads[A, Repr <: Coproduct](implicit
+      gen: LabelledGeneric.Aux[A, Repr],
+      reads: FlatTypeReads[Repr]): FlatTypeReads[A] =
+    create[A] { json => reads reads json map { gen.from }
+  }
+}

--- a/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/FlatTypeWrites.scala
+++ b/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/FlatTypeWrites.scala
@@ -1,0 +1,39 @@
+package com.evolutiongaming.util.generic
+import play.api.libs.json._
+import shapeless._
+import shapeless.labelled.FieldType
+
+trait FlatTypeWrites[A] extends Writes[A] {
+  override def writes(o: A): JsObject
+}
+
+object FlatTypeWrites {
+
+  def apply[A](implicit encode: FlatTypeWrites[A]): Writes[A] = new Writes[A] {
+    def writes(o: A): JsValue = encode writes o
+  }
+
+  def create[A](f: A => JsObject): FlatTypeWrites[A] = new FlatTypeWrites[A] {
+    override def writes(o: A): JsObject = f(o)
+  }
+
+  implicit def cnilWrites: FlatTypeWrites[CNil] = create[CNil] { _ =>
+    sys.error("Cannot encode CNil")
+  }
+
+  implicit def cconsWrites[Key <: Symbol, Head, Tail <: Coproduct](implicit
+      key: Witness.Aux[Key],
+      headWrites: OWrites[Head],
+      tailWrites: FlatTypeWrites[Tail]): FlatTypeWrites[FieldType[Key, Head] :+: Tail] =
+    create[FieldType[Key, Head] :+: Tail] {
+      _.eliminate(
+        head => Json.obj("type" -> s"${ key.value.name }") ++ (headWrites writes head),
+        tail => tailWrites writes tail
+      )
+    }
+
+  implicit def flatTypeWrites[A, Repr <: Coproduct](implicit
+      gen: LabelledGeneric.Aux[A, Repr],
+      writes: FlatTypeWrites[Repr]
+  ): FlatTypeWrites[A] = create[A] { a => writes writes gen.to(a) }
+}

--- a/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/NestedTypeFormat.scala
+++ b/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/NestedTypeFormat.scala
@@ -1,0 +1,8 @@
+package com.evolutiongaming.util.generic
+
+import play.api.libs.json.OFormat
+
+object NestedTypeFormat {
+  def apply[A](implicit reads: NestedTypeReads[A], writes: NestedTypeWrites[A]): OFormat[A] =
+    OFormat(reads reads _, writes writes _)
+}

--- a/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/NestedTypeReads.scala
+++ b/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/NestedTypeReads.scala
@@ -1,0 +1,50 @@
+package com.evolutiongaming.util.generic
+
+import play.api.libs.json._
+import shapeless._
+import shapeless.labelled._
+import Util.ClassTagOps
+
+import scala.reflect.ClassTag
+
+trait NestedTypeReads[T] extends Reads[T] {
+  override def reads(jsValue: JsValue): JsResult[T]
+}
+
+object NestedTypeReads {
+
+  def apply[A](implicit decode: NestedTypeReads[A]): NestedTypeReads[A] = decode
+
+  def create[A](f: JsValue => JsResult[A]): NestedTypeReads[A] = new NestedTypeReads[A] {
+    override def reads(json: JsValue): JsResult[A] = f(json)
+  }
+
+  implicit def cnilReads: NestedTypeReads[CNil] = create[CNil] { _ =>
+    JsError("could not decode cnil")
+  }
+
+  implicit def cconsReads[Key <: Symbol, Head, Tail <: Coproduct](implicit
+      headReads: Reads[Head],
+      tailReads: NestedTypeReads[Tail],
+      tag: ClassTag[Head]): NestedTypeReads[FieldType[Key, Head] :+: Tail] =
+    create[FieldType[Key, Head] :+: Tail] { json =>
+
+      for {
+        o <- json.validate[JsObject]
+        typ <- (o \ "type").validate[String]
+        res <- if (typ == tag.classFullName()) {
+          headReads reads (o - "type") map { z => Inl(field[Key](z)) }
+        }
+        else {
+          tailReads reads o map { Inr(_) }
+        }
+      } yield res
+    }
+
+  implicit def nestedTypeReads[A, Repr <: Coproduct](implicit
+      gen: LabelledGeneric.Aux[A, Repr],
+      reads: NestedTypeReads[Repr]): NestedTypeReads[A] =
+    create[A] {
+      json => reads reads json map { gen.from }
+    }
+}

--- a/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/NestedTypeWrites.scala
+++ b/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/NestedTypeWrites.scala
@@ -1,0 +1,43 @@
+package com.evolutiongaming.util.generic
+import play.api.libs.json._
+import shapeless._
+import shapeless.labelled.FieldType
+import Util.ClassTagOps
+
+import scala.reflect.ClassTag
+
+trait NestedTypeWrites[A] extends Writes[A] {
+  override def writes(o: A): JsObject
+}
+
+object NestedTypeWrites {
+
+  def apply[A](implicit encode: NestedTypeWrites[A]): Writes[A] = new Writes[A] {
+    def writes(o: A): JsValue = encode writes o
+  }
+
+  def create[A](f: A => JsObject): NestedTypeWrites[A] = new NestedTypeWrites[A] {
+    override def writes(o: A): JsObject = f(o)
+  }
+
+  implicit def cnilWrites: NestedTypeWrites[CNil] = NestedTypeWrites.create[CNil] { _ =>
+    sys.error("Cannot encode CNil")
+  }
+
+  implicit def cconsWrites[Key <: Symbol, Head, Tail <: Coproduct](implicit
+    headWrites: OWrites[Head],
+    tailWrites: NestedTypeWrites[Tail],
+    tag: ClassTag[Head])
+  : NestedTypeWrites[FieldType[Key, Head] :+: Tail] =
+    NestedTypeWrites.create[FieldType[Key, Head] :+: Tail] {
+      _.eliminate(
+        head => Json.obj("type" -> tag.classFullName()) ++ (headWrites writes head),
+        tail => tailWrites writes tail
+      )
+    }
+
+  implicit def nestedTypeWrites[A, Repr <: Coproduct](implicit
+    gen: LabelledGeneric.Aux[A, Repr],
+    writes: NestedTypeWrites[Repr]
+  ): NestedTypeWrites[A] = NestedTypeWrites.create[A] { a => writes writes gen.to(a) }
+}

--- a/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/Util.scala
+++ b/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/Util.scala
@@ -1,0 +1,20 @@
+package com.evolutiongaming.util.generic
+
+import scala.reflect.ClassTag
+
+object Util {
+
+  implicit class ClassTagOps[T](self: ClassTag[T]) extends AnyRef {
+
+    def classFullName(omitBaseClass: Boolean = true): String = {
+      val name = self.runtimeClass.getName
+      val idx = name.lastIndexOf('.')
+      val parts = name.substring(idx + 1).split('$').filterNot(_.isEmpty)
+
+      if (omitBaseClass)
+        parts.tail.mkString(".")
+      else
+        parts.mkString(".")
+    }
+  }
+}

--- a/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/Util.scala
+++ b/play-json-generic/src/main/scala/com/evolutiongaming/util/generic/Util.scala
@@ -4,7 +4,7 @@ import scala.reflect.ClassTag
 
 object Util {
 
-  implicit class ClassTagOps[T](self: ClassTag[T]) extends AnyRef {
+  implicit class ClassTagOps[T](val self: ClassTag[T]) extends AnyVal {
 
     def classFullName(omitBaseClass: Boolean = true): String = {
       val name = self.runtimeClass.getName

--- a/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/FlatTypeFormatSpec.scala
+++ b/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/FlatTypeFormatSpec.scala
@@ -7,10 +7,25 @@ class FlatTypeFormatSpec extends JsonFormatSpec {
 
   "FlatTypeFormat" should {
 
+    implicit val messageFormat = {
+
+      implicit val noopFormat: OFormat[Noop.type] = new OFormat[Noop.type] {
+        def writes(o: Noop.type): JsObject = Json.obj()
+        def reads(json: JsValue): JsResult[Message.Noop.type] = JsSuccess(Message.Noop)
+      }
+
+      implicit val ackFormat: OFormat[Out.Ack.type] = new OFormat[Out.Ack.type] {
+        def writes(o: Out.Ack.type): JsObject= Json.obj()
+        def reads(json: JsValue): JsResult[Out.Ack.type] = JsSuccess(Out.Ack)
+      }
+
+      implicit val updateFormat: OFormat[In.Update] = Json.format[In.Update]
+      implicit val updatedFormat: OFormat[Out.Updated] = Json.format[Out.Updated]
+
+      FlatTypeFormat[Message]
+    }
+
     "be able to read and write sealed trait hierarchy using simple name as a type discriminator" in {
-
-      implicit val format = MessageFormat
-
       for {
         (o, json) <- Seq(
           Noop -> Json.obj("type" -> "Noop"),
@@ -20,23 +35,6 @@ class FlatTypeFormatSpec extends JsonFormatSpec {
         )
       } yield check[Message](o, json)
     }
-  }
-
-  val MessageFormat = {
-    implicit val noopFormat: OFormat[Noop.type] = new OFormat[Noop.type] {
-      def writes(o: Noop.type): JsObject = Json.obj()
-      def reads(json: JsValue): JsResult[Message.Noop.type] = JsSuccess(Message.Noop)
-    }
-
-    implicit val ackFormat: OFormat[Out.Ack.type] = new OFormat[Out.Ack.type] {
-      def writes(o: Out.Ack.type): JsObject= Json.obj()
-      def reads(json: JsValue): JsResult[Out.Ack.type] = JsSuccess(Out.Ack)
-    }
-
-    implicit val updateFormat: OFormat[In.Update] = Json.format[In.Update]
-    implicit val updatedFormat: OFormat[Out.Updated] = Json.format[Out.Updated]
-
-    FlatTypeFormat[Message]
   }
 
 }

--- a/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/FlatTypeFormatSpec.scala
+++ b/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/FlatTypeFormatSpec.scala
@@ -1,0 +1,42 @@
+package com.evolutiongaming.util.generic
+
+import play.api.libs.json._
+import Message._
+
+class FlatTypeFormatSpec extends JsonFormatSpec {
+
+  "FlatTypeFormat" should {
+
+    "be able to read and write sealed trait hierarchy using simple name as a type discriminator" in {
+
+      implicit val format = MessageFormat
+
+      for {
+        (o, json) <- Seq(
+          Noop -> Json.obj("type" -> "Noop"),
+          In.Update(42) -> Json.obj("type" -> "Update", "payload" -> 42),
+          Out.Updated("test") -> Json.obj("type" -> "Updated", "v" -> "test"),
+          Out.Ack -> Json.obj("type" -> "Ack")
+        )
+      } yield check[Message](o, json)
+    }
+  }
+
+  val MessageFormat = {
+    implicit val noopFormat: OFormat[Noop.type] = new OFormat[Noop.type] {
+      def writes(o: Noop.type): JsObject = Json.obj()
+      def reads(json: JsValue): JsResult[Message.Noop.type] = JsSuccess(Message.Noop)
+    }
+
+    implicit val ackFormat: OFormat[Out.Ack.type] = new OFormat[Out.Ack.type] {
+      def writes(o: Out.Ack.type): JsObject= Json.obj()
+      def reads(json: JsValue): JsResult[Out.Ack.type] = JsSuccess(Out.Ack)
+    }
+
+    implicit val updateFormat: OFormat[In.Update] = Json.format[In.Update]
+    implicit val updatedFormat: OFormat[Out.Updated] = Json.format[Out.Updated]
+
+    FlatTypeFormat[Message]
+  }
+
+}

--- a/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/JsonFormatSpec.scala
+++ b/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/JsonFormatSpec.scala
@@ -1,0 +1,12 @@
+package com.evolutiongaming.util.generic
+
+import org.scalatest.{Assertion, Matchers, WordSpec}
+import play.api.libs.json.{Format, JsObject, JsSuccess}
+
+class JsonFormatSpec extends WordSpec with Matchers {
+
+  def check[T](o: T, json: JsObject)(implicit format: Format[T]): Assertion = {
+    withClue(s"writing $o: ") { format.writes(o) shouldEqual json }
+    withClue(s"reading $o: ") { format.reads(json) shouldEqual JsSuccess(o) }
+  }
+}

--- a/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/Message.scala
+++ b/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/Message.scala
@@ -1,0 +1,20 @@
+package com.evolutiongaming.util.generic
+
+sealed trait Message
+
+object Message {
+  sealed trait In extends Message
+
+  object In {
+    final case class Update(payload: Int) extends In
+  }
+
+  sealed trait Out extends Message
+
+  object Out {
+    object Ack extends Out
+    final case class Updated(v: String) extends Out
+  }
+
+  object Noop extends Message
+}

--- a/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/NestedTypeFormatSpec.scala
+++ b/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/NestedTypeFormatSpec.scala
@@ -1,0 +1,41 @@
+package com.evolutiongaming.util.generic
+
+import play.api.libs.json._
+import Message._
+
+class NestedTypeFormatSpec extends JsonFormatSpec {
+
+  "NestedTypeFormat" should {
+
+    "be able to read and write sealed trait hierarchy using full type name as a discriminator" in {
+
+      implicit val format = MessageFormat
+
+      for {
+        (o, json) <- Seq(
+          Noop -> Json.obj("type" -> "Noop"),
+          In.Update(42) -> Json.obj("type" -> "In.Update", "payload" -> 42),
+          Out.Updated("test") -> Json.obj("type" -> "Out.Updated", "v" -> "test"),
+          Out.Ack -> Json.obj("type" -> "Out.Ack")
+        )
+      } yield check[Message](o, json)
+    }
+  }
+
+  val MessageFormat = {
+    implicit val noopFormat: OFormat[Noop.type] = new OFormat[Noop.type] {
+      def writes(o: Noop.type): JsObject = Json.obj()
+      def reads(json: JsValue): JsResult[Message.Noop.type] = JsSuccess(Message.Noop)
+    }
+
+    implicit val ackFormat: OFormat[Out.Ack.type] = new OFormat[Out.Ack.type] {
+      def writes(o: Out.Ack.type): JsObject= Json.obj()
+      def reads(json: JsValue): JsResult[Out.Ack.type] = JsSuccess(Out.Ack)
+    }
+
+    implicit val updateFormat: OFormat[In.Update] = Json.format[In.Update]
+    implicit val updatedFormat: OFormat[Out.Updated] = Json.format[Out.Updated]
+
+    NestedTypeFormat[Message]
+  }
+}

--- a/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/NestedTypeFormatSpec.scala
+++ b/play-json-generic/src/test/scala/com/evolutiongaming/util/generic/NestedTypeFormatSpec.scala
@@ -5,24 +5,7 @@ import Message._
 
 class NestedTypeFormatSpec extends JsonFormatSpec {
 
-  "NestedTypeFormat" should {
-
-    "be able to read and write sealed trait hierarchy using full type name as a discriminator" in {
-
-      implicit val format = MessageFormat
-
-      for {
-        (o, json) <- Seq(
-          Noop -> Json.obj("type" -> "Noop"),
-          In.Update(42) -> Json.obj("type" -> "In.Update", "payload" -> 42),
-          Out.Updated("test") -> Json.obj("type" -> "Out.Updated", "v" -> "test"),
-          Out.Ack -> Json.obj("type" -> "Out.Ack")
-        )
-      } yield check[Message](o, json)
-    }
-  }
-
-  val MessageFormat = {
+  implicit val messageFormat = {
     implicit val noopFormat: OFormat[Noop.type] = new OFormat[Noop.type] {
       def writes(o: Noop.type): JsObject = Json.obj()
       def reads(json: JsValue): JsResult[Message.Noop.type] = JsSuccess(Message.Noop)
@@ -37,5 +20,19 @@ class NestedTypeFormatSpec extends JsonFormatSpec {
     implicit val updatedFormat: OFormat[Out.Updated] = Json.format[Out.Updated]
 
     NestedTypeFormat[Message]
+  }
+
+  "NestedTypeFormat" should {
+
+    "be able to read and write sealed trait hierarchy using full type name as a discriminator" in {
+      for {
+        (o, json) <- Seq(
+          Noop -> Json.obj("type" -> "Noop"),
+          In.Update(42) -> Json.obj("type" -> "In.Update", "payload" -> 42),
+          Out.Updated("test") -> Json.obj("type" -> "Out.Updated", "v" -> "test"),
+          Out.Ack -> Json.obj("type" -> "Out.Ack")
+        )
+      } yield check[Message](o, json)
+    }
   }
 }


### PR DESCRIPTION
Added coproduct formats derived by Shapeless:

1. FlatTypeFormat (with simple class names) 
2. Added NestedTypeFormat (preserves nested structure in labels)