### PR TITLE
remove note about play-json-generic not being available for scala 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 3. `play-json-jsoniter` — provides the fastest way to convert an instance of `play.api.libs.json.JsValue` to byte array and read it back.
 4. `play-json-circe` — provides conversions to/from `circe` codecs to ease transitions from one library to another. Examples in [CirceToPlayConversionsSpec](play-json-circe/src/test/scala/com/evolution/playjson/circe/CirceToPlayConversionsSpec.scala) and [PlayToCirceConversionsSpec](play-json-circe/src/test/scala/com/evolution/playjson/circe/PlayToCirceConversionsSpec.scala).
 
-All modules are available for Scala 2.12, 2.13 and 3, except for `play-json-generic`, which has no Scala 3 version yet.
+All modules are available for Scala 2.12, 2.13 and 3.
 
 ## Setup
 


### PR DESCRIPTION
remove note about play-json-generic not being available for scala 3