### PR TITLE
Update Scala versions and most of the dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         scala:
           - 2.13.16
-          - 2.12.20
           - 3.3.6
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         scala:
-          - 2.13.16
-          - 3.3.6
+          - 2.13.18
+          - 3.3.8
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 3. `play-json-jsoniter` — provides the fastest way to convert an instance of `play.api.libs.json.JsValue` to byte array and read it back.
 4. `play-json-circe` — provides conversions to/from `circe` codecs to ease transitions from one library to another. Examples in [CirceToPlayConversionsSpec](play-json-circe/src/test/scala/com/evolution/playjson/circe/CirceToPlayConversionsSpec.scala) and [PlayToCirceConversionsSpec](play-json-circe/src/test/scala/com/evolution/playjson/circe/PlayToCirceConversionsSpec.scala).
 
-All modules are available for Scala 2.12, 2.13 and 3.
+All modules are available for 2.13 and 3.
 
 ## Setup
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import Dependencies.*
 
 import scala.collection.Seq
 
-val Scala213 = "2.13.16"
-val Scala3   = "3.3.6"
+val Scala213 = "2.13.18"
+val Scala3   = "3.3.8"
 
 val commonSettings = Seq(
   homepage := Some(url("https://github.com/evolution-gaming/play-json-tools")),

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import Dependencies.*
 import scala.collection.Seq
 
 val Scala213 = "2.13.16"
-val Scala212 = "2.12.20"
 val Scala3   = "3.3.6"
 
 val commonSettings = Seq(
@@ -16,22 +15,21 @@ val commonSettings = Seq(
   description := "Set of implicit helper classes for transforming various objects to and from JSON",
   startYear := Some(2017),
   scalaVersion := Scala213,
-  crossScalaVersions := Seq(scalaVersion.value, Scala212, Scala3),
+  crossScalaVersions := Seq(scalaVersion.value, Scala3),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v >= 13 =>
+      case Some((2, _)) =>
         List(
           "-Xsource:3",
         )
       case _ =>
-        Nil
+        List(
+          // improve error messages:
+          "-explain",
+          "-explain-types",
+        )
     }
   },
-  // precaution to NOT allow accidental transitive dependency
-  excludeDependencies ++= Seq(
-    ExclusionRule("com.typesafe.play", "play-json_2.13"),
-    ExclusionRule("com.typesafe.play", "play-functional_2.13"),
-  ),
 )
 
 val alias: Seq[sbt.Def.Setting[?]] =
@@ -69,7 +67,7 @@ lazy val `play-json-generic` = crossProject(JVMPlatform, JSPlatform)
       playJson,
       scalaTest % Test
     ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v >= 12 =>
+      case Some((2, _)) =>
         Seq(shapeless)
       case _ =>
         Seq()
@@ -100,7 +98,7 @@ lazy val `play-json-jsoniter` = crossProject(JVMPlatform, JSPlatform)
       collectionCompact,
       scalaTest % Test
     ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v >= 13 =>
+      case Some((2, _)) =>
         Seq(jsonGenerator % Test)
       case _ =>
         Seq()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,16 +2,16 @@ import sbt._
 
 object Dependencies {
 
-  val shapeless = "com.chuusai"         %% "shapeless" % "2.3.10"
+  val shapeless = "com.chuusai"         %% "shapeless" % "2.3.13"
   val nel       = "com.evolutiongaming" %% "nel"       % "1.3.5"
   val playJson  = "org.playframework"   %% "play-json" % "3.0.6"
-  val scalaTest = "org.scalatest"       %% "scalatest" % "3.2.19"
-  val jsoniter  = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"  % "2.36.7"
+  val scalaTest = "org.scalatest"       %% "scalatest" % "3.2.20"
+  val jsoniter  = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"  % "2.39.1"
   val jsonGenerator = "com.github.imrafaelmerino" %% "json-scala-values-generator" % "1.0.0"
-  val collectionCompact = "org.scala-lang.modules" %% "scala-collection-compat" % "2.10.0"
+  val collectionCompact = "org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0"
 
   object circe {
-    val version  = "0.14.14"
+    val version  = "0.14.16"
     val core     = "io.circe" %% "circe-core"   % version
     val parser   = "io.circe" %% "circe-parser" % version
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.3
+sbt.version = 1.12.14

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,10 @@
-externalResolvers += Resolver.bintrayIvyRepo("evolutiongaming", "sbt-plugins")
-
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.18.2")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.22.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 


### PR DESCRIPTION
* Drop Scala 2.12 support
* Bump Scala versions to 2.13.18 and 3.3.8
* Bump SBT to 1.12.14
* Update most of the dependencies
* Do not update `json-scala-values-generator` as it requires significant code review and explicit dependency on `scalacheck`