### PR TITLE
Consistent BigDecimal serialization in play-json-jsoniter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ src_managed/
 project/boot/
 project/plugins/project/
 
+# JMH
+jmh-result.*
+
 # Bloop
 .bsp
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 1. `play-json-tools` — Set of implicit Play-JSON `Format` helper classes. Example in [FlatFormatSpec](play-json-tools/src/test/scala/com/evolution/playjson/tools/FlatFormatSpec.scala)
 2. `play-json-generic` — provides Format derivation for enum like adt's (sealed trait/case objects'). Examples in [EnumerationDerivalSpec](play-json-generic/src/test/scala/com/evolution/playjson/generic/EnumerationDerivalSpec.scala)
 3. `play-json-jsoniter` — provides the fastest way to convert an instance of `play.api.libs.json.JsValue` to byte array and read it back.
+   Numbers are written exactly as play-json writes them, which means a `BigDecimal` keeps its value
+   but not necessarily its scale: `100.00` is written as `100`. A number that could not be read back
+   under the configured parse limits is rejected with a `JsonWriterException` instead of being
+   written.
 4. `play-json-circe` — provides conversions to/from `circe` codecs to ease transitions from one library to another. Examples in [CirceToPlayConversionsSpec](play-json-circe/src/test/scala/com/evolution/playjson/circe/CirceToPlayConversionsSpec.scala) and [PlayToCirceConversionsSpec](play-json-circe/src/test/scala/com/evolution/playjson/circe/PlayToCirceConversionsSpec.scala).
 
 All modules are available for 2.13 and 3.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 1. `play-json-tools` — Set of implicit Play-JSON `Format` helper classes. Example in [FlatFormatSpec](play-json-tools/src/test/scala/com/evolution/playjson/tools/FlatFormatSpec.scala)
 2. `play-json-generic` — provides Format derivation for enum like adt's (sealed trait/case objects'). Examples in [EnumerationDerivalSpec](play-json-generic/src/test/scala/com/evolution/playjson/generic/EnumerationDerivalSpec.scala)
 3. `play-json-jsoniter` — provides the fastest way to convert an instance of `play.api.libs.json.JsValue` to byte array and read it back.
-   Numbers are written exactly as play-json writes them, which means a `BigDecimal` keeps its value
+   Numbers are written exactly as play-json's JVM serializer writes them, which means a `BigDecimal` keeps its value
    but not necessarily its scale: `100.00` is written as `100`. A number that could not be read back
    under the configured parse limits is rejected with a `JsonWriterException` instead of being
    written.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -18,7 +18,7 @@ Variants:
 
 | Variant | What it is |
 | --- | --- |
-| `pre 1.4` | `play-json-jsoniter` before BigDecimal write parity, `JsNumber` passed straight to jsoniter's `writeVal` |
+| `pre 1.4` | `play-json-jsoniter` before BigDecimal write parity, `JsNumber` passed straight to jsoniter's `writeVal`, the codec as of `cf23acb` |
 | `post 1.4` | `play-json-jsoniter` at 1.4, the `*Current` benchmarks |
 | `play-json` | play-json alone, `Json.toBytes` and `Json.parse` |
 | `circe` | circe alone, `noSpaces` and `io.circe.parser.parse`, on a circe `Json` |
@@ -33,11 +33,19 @@ Payloads:
 | `trailingZeros` | 1000 values with scale 4 and trailing zeros |
 | `document` | the shared `TestData` document, a realistic object with few numbers |
 
-Throughput in ops/s, higher is better. Apple M1 Pro, OpenJDK 25.0.3, Scala 2.13.18:
+Throughput in ops/s, higher is better. Each cell is the JMH score and its error.
 
-```sh
-sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s com.evolution.playjson.jsoniter.JsNumber.*Benchmark"
-```
+Measured on 2026-08-04:
+
+| | |
+| --- | --- |
+| Machine | Apple M1 Pro, macOS 26.5.2 |
+| JDK | OpenJDK 25.0.3 |
+| Scala | 2.13.18 |
+| Command | `sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s com.evolution.playjson.jsoniter.JsNumber.*Benchmark"` |
+
+Keep these figures as a record. A rerun on another JDK or machine belongs in a section of its own,
+so the older numbers stay available for comparison.
 
 ### Writing
 
@@ -59,5 +67,7 @@ sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s com.evolution.playjson.jsonit
 
 `circe` produces a circe `Json`. Every other column produces a play-json `JsValue`.
 
-`pre 1.4` was measured before the change. The code producing it is not in the repository, so a
-rerun reproduces every other column.
+The `pre 1.4` codec is not in the repository, so a rerun reproduces every column but that one:
+[JsonValueCodecJsValue.scala at cf23acb](https://github.com/evolution-gaming/play-json-tools/blob/cf23acb932f2f79cc06158da58a0480bec0bfd7c/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala).
+To measure it again, add that file to the benchmark sources under another name and give each
+benchmark a variant using it.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,63 @@
+# Benchmarks
+
+JMH benchmarks for `play-json-jsoniter`. The module is not part of the aggregate build, so
+`sbt test` and CI never run it. Run them by hand:
+
+```sh
+sbt benchmark/Jmh/run                                                            # everything
+sbt "benchmark/Jmh/run com.evolution.playjson.jsoniter.JsNumberWriteBenchmark"   # one suite
+sbt "benchmark/Jmh/run -prof gc JsNumberWriteBenchmark.integers.*"               # allocation too
+```
+
+`-f` forks, `-wi`/`-w` warmup iterations and duration, `-i`/`-r` measurement iterations and
+duration, `-rf json -rff out.json` to save results. These override the annotations on the class.
+
+## Results
+
+Variants:
+
+| Variant | What it is |
+| --- | --- |
+| `pre 1.4` | `play-json-jsoniter` before BigDecimal write parity, `JsNumber` passed straight to jsoniter's `writeVal` |
+| `post 1.4` | `play-json-jsoniter` at 1.4, the `*Current` benchmarks |
+| `play-json` | play-json alone, `Json.toBytes` and `Json.parse` |
+| `circe` | circe alone, `noSpaces` and `io.circe.parser.parse`, on a circe `Json` |
+| `play-circe` | a play-json `JsValue` through `play-json-circe` and circe, conversion included |
+
+Payloads:
+
+| Payload | What it is |
+| --- | --- |
+| `integers` | 1000 whole numbers |
+| `decimals` | 1000 values with two decimal places |
+| `trailingZeros` | 1000 values with scale 4 and trailing zeros |
+| `document` | the shared `TestData` document, a realistic object with few numbers |
+
+Throughput in ops/s, higher is better. Apple M1 Pro, OpenJDK 25.0.3, Scala 2.13.18:
+
+```sh
+sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s com.evolution.playjson.jsoniter.JsNumber.*Benchmark"
+```
+
+### Writing
+
+| Payload | pre 1.4 | post 1.4 | play-json | circe | play-circe |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `integers` | 59 808 ± 7 711 | 172 441 ± 4 552 | 5 518 ± 112 | 89 225 ± 1 343 | 11 809 ± 494 |
+| `decimals` | 97 730 ± 4 184 | 62 447 ± 2 040 | 10 213 ± 684 | 62 961 ± 1 161 | 12 891 ± 243 |
+| `trailingZeros` | 60 098 ± 1 697 | 32 076 ± 330 | 5 052 ± 186 | 66 238 ± 1 919 | 12 959 ± 271 |
+| `document` | 342 120 ± 7 766 | 375 279 ± 7 174 | 415 715 ± 16 185 | 392 914 ± 44 219 | 169 168 ± 5 197 |
+
+### Reading
+
+| Payload | pre 1.4 | post 1.4 | play-json | circe | play-circe |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `integers` | 48 155 ± 10 057 | 50 448 ± 1 241 | 16 927 ± 2 539 | 52 301 ± 4 326 | 12 185 ± 99 |
+| `decimals` | 47 424 ± 365 | 45 610 ± 1 355 | 11 799 ± 89 | 60 821 ± 1 390 | 6 444 ± 154 |
+| `trailingZeros` | 41 103 ± 1 240 | 41 577 ± 351 | 12 284 ± 304 | 55 116 ± 5 335 | 6 552 ± 57 |
+| `document` | 626 094 ± 10 795 | 640 621 ± 19 294 | 285 091 ± 27 457 | 254 644 ± 4 584 | 124 107 ± 5 423 |
+
+`circe` produces a circe `Json`. Every other column produces a play-json `JsValue`.
+
+`pre 1.4` was measured before the change. The code producing it is not in the repository, so a
+rerun reproduces every other column.

--- a/benchmark/src/test/scala/com/evolution/playjson/jsoniter/JsNumberReadBenchmark.scala
+++ b/benchmark/src/test/scala/com/evolution/playjson/jsoniter/JsNumberReadBenchmark.scala
@@ -1,0 +1,70 @@
+package com.evolution.playjson.jsoniter
+
+import com.evolution.playjson.circe.PlayCirceAstConversions.circeToPlay
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, readFromArray}
+import io.circe.parser.{parse => parseCirce}
+import org.openjdk.jmh.annotations.{Benchmark, Fork, Measurement, Scope, State, Warmup}
+import org.openjdk.jmh.infra.Blackhole
+import play.api.libs.json._
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+/**
+ * The read counterpart of [[JsNumberWriteBenchmark]], over the same payloads.
+ *
+ * To run: {{{sbt benchmark/Jmh/run com.evolution.playjson.jsoniter.JsNumberReadBenchmark}}}
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+class JsNumberReadBenchmark {
+
+  private val parseSettings = JsonConfig.settings.bigDecimalParseConfig
+
+  private val current: JsonValueCodec[JsValue] =
+    JsonValueCodecJsValue(parseSettings, JsonConfig.settings.bigDecimalSerializerConfig)
+
+  // written out as text rather than through a codec, so the payloads do not depend on the writer
+  // being measured elsewhere
+  private def arrayOf(values: Seq[BigDecimal]): Array[Byte] =
+    values.mkString("[", ",", "]").getBytes(StandardCharsets.UTF_8)
+
+  private val integers = arrayOf((1 to 1000).map(BigDecimal(_)))
+
+  private val decimals = arrayOf((1 to 1000).map(index => BigDecimal(index) / 100))
+
+  private val trailingZeros = arrayOf((1 to 1000).map(index => BigDecimal(index).setScale(4)))
+
+  private val document = TestData.jsonBody.getBytes(StandardCharsets.UTF_8)
+
+  // circe parses text, so it is given the same bytes as a string
+  private val integersAsText = new String(integers, StandardCharsets.UTF_8)
+  private val decimalsAsText = new String(decimals, StandardCharsets.UTF_8)
+  private val trailingZerosAsText = new String(trailingZeros, StandardCharsets.UTF_8)
+  private val documentAsText = new String(document, StandardCharsets.UTF_8)
+
+  private def playViaCirce(text: String): JsValue =
+    parseCirce(text).fold(throw _, circeToPlay)
+
+  @Benchmark def integersCurrent(hole: Blackhole): Unit = hole.consume(readFromArray(integers)(current))
+  @Benchmark def integersPlayJson(hole: Blackhole): Unit = hole.consume(Json.parse(integers))
+  @Benchmark def integersCirce(hole: Blackhole): Unit = hole.consume(parseCirce(integersAsText))
+  @Benchmark def integersPlayCirce(hole: Blackhole): Unit = hole.consume(playViaCirce(integersAsText))
+
+  @Benchmark def decimalsCurrent(hole: Blackhole): Unit = hole.consume(readFromArray(decimals)(current))
+  @Benchmark def decimalsPlayJson(hole: Blackhole): Unit = hole.consume(Json.parse(decimals))
+  @Benchmark def decimalsCirce(hole: Blackhole): Unit = hole.consume(parseCirce(decimalsAsText))
+  @Benchmark def decimalsPlayCirce(hole: Blackhole): Unit = hole.consume(playViaCirce(decimalsAsText))
+
+  @Benchmark def trailingZerosCurrent(hole: Blackhole): Unit = hole.consume(readFromArray(trailingZeros)(current))
+  @Benchmark def trailingZerosPlayJson(hole: Blackhole): Unit = hole.consume(Json.parse(trailingZeros))
+  @Benchmark def trailingZerosCirce(hole: Blackhole): Unit = hole.consume(parseCirce(trailingZerosAsText))
+  @Benchmark def trailingZerosPlayCirce(hole: Blackhole): Unit = hole.consume(playViaCirce(trailingZerosAsText))
+
+  @Benchmark def documentCurrent(hole: Blackhole): Unit = hole.consume(readFromArray(document)(current))
+  @Benchmark def documentPlayJson(hole: Blackhole): Unit = hole.consume(Json.parse(document))
+  @Benchmark def documentCirce(hole: Blackhole): Unit = hole.consume(parseCirce(documentAsText))
+  @Benchmark def documentPlayCirce(hole: Blackhole): Unit = hole.consume(playViaCirce(documentAsText))
+}

--- a/benchmark/src/test/scala/com/evolution/playjson/jsoniter/JsNumberWriteBenchmark.scala
+++ b/benchmark/src/test/scala/com/evolution/playjson/jsoniter/JsNumberWriteBenchmark.scala
@@ -1,0 +1,72 @@
+package com.evolution.playjson.jsoniter
+
+import com.evolution.playjson.circe.PlayCirceAstConversions.playToCirce
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, writeToArray}
+import io.circe.{Json => CirceJson}
+import org.openjdk.jmh.annotations.{Benchmark, Fork, Measurement, Scope, State, Warmup}
+import org.openjdk.jmh.infra.Blackhole
+import play.api.libs.json._
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+/**
+ * Throughput of turning a play-json `JsValue` into bytes, over payloads that exercise the
+ * `JsNumber` branch of `encodeValue`, with play-json and circe as reference points.
+ *
+ * To run: {{{sbt benchmark/Jmh/run com.evolution.playjson.jsoniter.JsNumberWriteBenchmark}}}
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+class JsNumberWriteBenchmark {
+
+  private val parseSettings = JsonConfig.settings.bigDecimalParseConfig
+
+  private implicit val current: JsonValueCodec[JsValue] =
+    JsonValueCodecJsValue(parseSettings, JsonConfig.settings.bigDecimalSerializerConfig)
+
+  private def arrayOf(values: Seq[BigDecimal]): JsValue = JsArray(values.map(JsNumber(_)))
+
+  // hits the scale == 0 fast path
+  private val integers = arrayOf((1 to 1000).map(BigDecimal(_)))
+
+  // two decimal places, the shape money tends to have
+  private val decimals = arrayOf((1 to 1000).map(index => BigDecimal(index) / 100))
+
+  // trailing zeros, so the value has to be normalized before it can be written
+  private val trailingZeros = arrayOf((1 to 1000).map(index => BigDecimal(index).setScale(4)))
+
+  private val document = Json.parse(TestData.jsonBody)
+
+  private def circeBytes(circeJson: CirceJson): Array[Byte] =
+    circeJson.noSpaces.getBytes(StandardCharsets.UTF_8)
+
+  // circe writing a value it already holds, against the same value reached through play-json-circe
+  private val integersAsCirce = playToCirce(integers)
+  private val decimalsAsCirce = playToCirce(decimals)
+  private val trailingZerosAsCirce = playToCirce(trailingZeros)
+  private val documentAsCirce = playToCirce(document)
+
+  @Benchmark def integersCurrent(hole: Blackhole): Unit = hole.consume(writeToArray(integers)(current))
+  @Benchmark def integersPlayJson(hole: Blackhole): Unit = hole.consume(Json.toBytes(integers))
+  @Benchmark def integersCirce(hole: Blackhole): Unit = hole.consume(circeBytes(integersAsCirce))
+  @Benchmark def integersPlayCirce(hole: Blackhole): Unit = hole.consume(circeBytes(playToCirce(integers)))
+
+  @Benchmark def decimalsCurrent(hole: Blackhole): Unit = hole.consume(writeToArray(decimals)(current))
+  @Benchmark def decimalsPlayJson(hole: Blackhole): Unit = hole.consume(Json.toBytes(decimals))
+  @Benchmark def decimalsCirce(hole: Blackhole): Unit = hole.consume(circeBytes(decimalsAsCirce))
+  @Benchmark def decimalsPlayCirce(hole: Blackhole): Unit = hole.consume(circeBytes(playToCirce(decimals)))
+
+  @Benchmark def trailingZerosCurrent(hole: Blackhole): Unit = hole.consume(writeToArray(trailingZeros)(current))
+  @Benchmark def trailingZerosPlayJson(hole: Blackhole): Unit = hole.consume(Json.toBytes(trailingZeros))
+  @Benchmark def trailingZerosCirce(hole: Blackhole): Unit = hole.consume(circeBytes(trailingZerosAsCirce))
+  @Benchmark def trailingZerosPlayCirce(hole: Blackhole): Unit =
+    hole.consume(circeBytes(playToCirce(trailingZeros)))
+
+  @Benchmark def documentCurrent(hole: Blackhole): Unit = hole.consume(writeToArray(document)(current))
+  @Benchmark def documentPlayJson(hole: Blackhole): Unit = hole.consume(Json.toBytes(document))
+  @Benchmark def documentCirce(hole: Blackhole): Unit = hole.consume(circeBytes(documentAsCirce))
+  @Benchmark def documentPlayCirce(hole: Blackhole): Unit = hole.consume(circeBytes(playToCirce(document)))
+}

--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,22 @@ lazy val `play-json-jsoniter` = crossProject(JVMPlatform, JSPlatform)
     })).map(excludeLog4j)
   )
 
+// not part of the aggregate, benchmarks are run manually
+lazy val benchmark = project
+  .dependsOn(
+    `play-json-jsoniterJVM` % "test->test;compile->compile",
+    `play-json-circe` % "test->test;compile->compile")
+  .disablePlugins(MimaPlugin)
+  .enablePlugins(JmhPlugin)
+  .settings(
+    commonSettings,
+    publish / skip := true,
+    crossScalaVersions := Seq(Scala213),
+    Jmh / sourceDirectory := (Test / sourceDirectory).value,
+    Jmh / classDirectory := (Test / classDirectory).value,
+    Jmh / dependencyClasspath := (Test / dependencyClasspath).value,
+  )
+
 lazy val `play-json-circe` = project
   .settings(
     commonSettings,

--- a/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/BigDecimalWriteContractSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/BigDecimalWriteContractSpec.scala
@@ -2,28 +2,25 @@ package com.evolution.playjson.jsoniter
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriterException
 import org.scalacheck.Prop.forAll
-import org.scalacheck.{Arbitrary, Gen, Test}
+import org.scalacheck.{Arbitrary, Gen}
 import play.api.libs.json.{JsNumber, JsValue, Json}
 
 import java.util.Arrays
 import scala.util.{Failure, Success, Try}
 
 /**
- * States the BigDecimal write contract of [[PlayJsonJsoniter]] once, over the whole range of
- * scales and precisions the reader has limits for, instead of over hand-picked examples:
- * serialization either fails, or produces bytes that both this codec and play-json can read.
+ * States the BigDecimal write contract of [[PlayJsonJsoniter]] once, over a range of scales and
+ * precisions, instead of over hand-picked examples: serialization either produces bytes that both
+ * this codec and play-json read the same way, or it fails for a value that genuinely could not
+ * have been read back.
  *
- * The limits themselves live in jsoniter's reader, so these properties are what notices if a
- * jsoniter upgrade moves a boundary the writer mirrors.
+ * The limits themselves live in jsoniter's reader. Their exact boundaries are pinned by
+ * `JsoniterBigDecimalRoundTripSpec`, which is what notices a jsoniter upgrade that moves one;
+ * these properties cover the range in between. The number of samples is whatever the ScalaCheck
+ * runner is configured with, so raise it with `-minSuccessfulTests` when changing the writer.
  */
 object BigDecimalWriteContractSpec extends org.scalacheck.Properties("BigDecimalWriteContract") {
 
-  val Size = 5000
-
-  override def overrideParameters(p: Test.Parameters): Test.Parameters =
-    p.withMinSuccessfulTests(Size)
-
-  // covers both sides of digitsLimit (310) and scaleLimit (6178)
   private val genUnscaled: Gen[BigInt] =
     Gen.choose(1, 320).flatMap(digits => Gen.listOfN(digits, Gen.numChar).map(chars => BigInt(chars.mkString)))
 
@@ -37,19 +34,26 @@ object BigDecimalWriteContractSpec extends org.scalacheck.Properties("BigDecimal
 
   private def jsonOf(value: BigDecimal): JsValue = JsNumber(value)
 
-  property("serialization either fails or produces bytes this codec can read") = forAll {
+  /**
+   * play-json writes any BigDecimal, and by the parity property below its bytes are the ones this
+   * writer would have produced, so they are the evidence of what a rejected value would have been.
+   */
+  private def playJsonBytesAreUnreadable(value: BigDecimal): Boolean =
+    PlayJsonJsoniter.deserialize(Json.toBytes(jsonOf(value))).isFailure
+
+  property("serialization either fails for good reason or produces bytes this codec can read") = forAll {
     (value: BigDecimal) =>
       Try(PlayJsonJsoniter.serialize(jsonOf(value))) match {
-        case Failure(_: JsonWriterException) => true
+        case Failure(_: JsonWriterException) => playJsonBytesAreUnreadable(value)
         case Failure(_) => false
         case Success(bytes) => PlayJsonJsoniter.deserialize(bytes).isSuccess
       }
   }
 
-  property("serialization either fails or produces the bytes play-json produces") = forAll {
+  property("serialization either fails for good reason or produces the bytes play-json produces") = forAll {
     (value: BigDecimal) =>
       Try(PlayJsonJsoniter.serialize(jsonOf(value))) match {
-        case Failure(_: JsonWriterException) => true
+        case Failure(_: JsonWriterException) => playJsonBytesAreUnreadable(value)
         case Failure(_) => false
         case Success(bytes) => Arrays.equals(bytes, Json.toBytes(jsonOf(value)))
       }

--- a/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/BigDecimalWriteContractSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/BigDecimalWriteContractSpec.scala
@@ -1,0 +1,57 @@
+package com.evolution.playjson.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriterException
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen, Test}
+import play.api.libs.json.{JsNumber, JsValue, Json}
+
+import java.util.Arrays
+import scala.util.{Failure, Success, Try}
+
+/**
+ * States the BigDecimal write contract of [[PlayJsonJsoniter]] once, over the whole range of
+ * scales and precisions the reader has limits for, instead of over hand-picked examples:
+ * serialization either fails, or produces bytes that both this codec and play-json can read.
+ *
+ * The limits themselves live in jsoniter's reader, so these properties are what notices if a
+ * jsoniter upgrade moves a boundary the writer mirrors.
+ */
+object BigDecimalWriteContractSpec extends org.scalacheck.Properties("BigDecimalWriteContract") {
+
+  val Size = 5000
+
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withMinSuccessfulTests(Size)
+
+  // covers both sides of digitsLimit (310) and scaleLimit (6178)
+  private val genUnscaled: Gen[BigInt] =
+    Gen.choose(1, 320).flatMap(digits => Gen.listOfN(digits, Gen.numChar).map(chars => BigInt(chars.mkString)))
+
+  private val genBigDecimal: Gen[BigDecimal] = for {
+    unscaled <- genUnscaled
+    scale <- Gen.oneOf(Gen.choose(-7000, 7000), Gen.choose(-40, 40))
+    negative <- Gen.oneOf(true, false)
+  } yield BigDecimal(if (negative) -unscaled else unscaled, scale)
+
+  implicit def generator: Arbitrary[BigDecimal] = Arbitrary(genBigDecimal)
+
+  private def jsonOf(value: BigDecimal): JsValue = JsNumber(value)
+
+  property("serialization either fails or produces bytes this codec can read") = forAll {
+    (value: BigDecimal) =>
+      Try(PlayJsonJsoniter.serialize(jsonOf(value))) match {
+        case Failure(_: JsonWriterException) => true
+        case Failure(_) => false
+        case Success(bytes) => PlayJsonJsoniter.deserialize(bytes).isSuccess
+      }
+  }
+
+  property("serialization either fails or produces the bytes play-json produces") = forAll {
+    (value: BigDecimal) =>
+      Try(PlayJsonJsoniter.serialize(jsonOf(value))) match {
+        case Failure(_: JsonWriterException) => true
+        case Failure(_) => false
+        case Success(bytes) => Arrays.equals(bytes, Json.toBytes(jsonOf(value)))
+      }
+  }
+}

--- a/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/PlayJsonWithJsoniterBackendSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/PlayJsonWithJsoniterBackendSpec.scala
@@ -34,6 +34,11 @@ object PlayJsonWithJsoniterBackendSpec extends org.scalacheck.Properties("PlayJs
     !bools.contains(false)
   }
 
+  property("Write using Jsoniter -> Read using PlayJson") = forAll { (user: User) =>
+    val bts = PlayJsonJsoniter.serialize(Json.toJson(user))
+    JsSuccess(user) == Json.fromJson[User](Json.parse(bts))
+  }
+
   property("Write using Jsoniter -> Read using Jsoniter. Batch") = forAll(
     Gen.containerOfN[Vector, User](Size, genUser),
   ) { (batch: Vector[User]) =>

--- a/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/RandomJsonArraysSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/RandomJsonArraysSpec.scala
@@ -5,6 +5,8 @@ import org.scalacheck.{Arbitrary, Gen, Test}
 import play.api.libs.json.Json
 import valuegen.RandomJsArrayGen
 
+import java.util.Arrays
+
 //sbt playJsonJsoniter/test:"runMain com.evolution.playjson.jsoniter.RandomJsonArraysSpec"
 object RandomJsonArraysSpec extends org.scalacheck.Properties("RandomJsonSpec") {
 
@@ -24,5 +26,16 @@ object RandomJsonArraysSpec extends org.scalacheck.Properties("RandomJsonSpec") 
     val bts = PlayJsonJsoniter.serialize(jsValue)
     val actJsValue = PlayJsonJsoniter.deserialize(bts)
     jsValue == actJsValue.get
+  }
+
+  property("Random json arrays: write using Jsoniter -> read using PlayJson") = forAll { (array: value.JsArray) =>
+    val jsValue = Json.parse(array.toString)
+    val bts = PlayJsonJsoniter.serialize(jsValue)
+    jsValue == Json.parse(bts)
+  }
+
+  property("Random json arrays: Jsoniter and PlayJson write the same bytes") = forAll { (array: value.JsArray) =>
+    val jsValue = Json.parse(array.toString)
+    Arrays.equals(PlayJsonJsoniter.serialize(jsValue), Json.toBytes(jsValue))
   }
 }

--- a/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/RandomJsonObjectsSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala-2.13/com/evolution/playjson/jsoniter/RandomJsonObjectsSpec.scala
@@ -5,6 +5,8 @@ import org.scalacheck.{Arbitrary, Gen, Test}
 import play.api.libs.json.Json
 import valuegen.RandomJsObjGen
 
+import java.util.Arrays
+
 //sbt playJsonJsoniter/test:"runMain com.evolution.playjson.jsoniter.RandomJsonObjectsSpec"
 object RandomJsonObjectsSpec extends org.scalacheck.Properties("RandomJsonObjectsSpec") {
 
@@ -24,5 +26,16 @@ object RandomJsonObjectsSpec extends org.scalacheck.Properties("RandomJsonObject
     val bts = PlayJsonJsoniter.serialize(jsValue)
     val actJsValue = PlayJsonJsoniter.deserialize(bts)
     jsValue == actJsValue.get
+  }
+
+  property("Random json objects: write using Jsoniter -> read using PlayJson") = forAll { (obj: value.JsObj) =>
+    val jsValue = Json.parse(obj.toString)
+    val bts = PlayJsonJsoniter.serialize(jsValue)
+    jsValue == Json.parse(bts)
+  }
+
+  property("Random json objects: Jsoniter and PlayJson write the same bytes") = forAll { (obj: value.JsObj) =>
+    val jsValue = Json.parse(obj.toString)
+    Arrays.equals(PlayJsonJsoniter.serialize(jsValue), Json.toBytes(jsValue))
   }
 }

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
@@ -86,6 +86,42 @@ class JsoniterBigDecimalRoundTripSpec extends AnyFunSuite with Matchers {
     }
   }
 
+  // The reader rejects at `digits >= digitsLimit` and `abs(scale) >= scaleLimit`, and the writer
+  // mirrors it. These four tests stand on either side of those two boundaries, so a jsoniter
+  // upgrade that moves one by a single digit fails the build instead of going unnoticed.
+
+  test("writes a value with one digit fewer than the read digits limit") {
+    val digitsLimit = JsonConfig.settings.bigDecimalParseConfig.digitsLimit
+    val largest = BigDecimal("1" + "0" * (digitsLimit - 3) + "7")
+
+    largest.precision shouldEqual digitsLimit - 1
+    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(jsonOf(largest))) shouldBe a[Success[_]]
+  }
+
+  test("rejects a value with exactly as many digits as the read digits limit") {
+    val digitsLimit = JsonConfig.settings.bigDecimalParseConfig.digitsLimit
+    val tooLong = BigDecimal("1" + "0" * (digitsLimit - 2) + "7")
+
+    tooLong.precision shouldEqual digitsLimit
+    a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(jsonOf(tooLong))
+  }
+
+  test("writes a value with one scale fewer than the read scale limit") {
+    val scaleLimit = JsonConfig.settings.bigDecimalParseConfig.scaleLimit
+
+    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(jsonOf(BigDecimal(1, scaleLimit - 1)))) shouldBe
+      a[Success[_]]
+    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(jsonOf(BigDecimal(1, -(scaleLimit - 1))))) shouldBe
+      a[Success[_]]
+  }
+
+  test("rejects a value whose scale reaches the read scale limit") {
+    val scaleLimit = JsonConfig.settings.bigDecimalParseConfig.scaleLimit
+
+    a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(jsonOf(BigDecimal(1, scaleLimit)))
+    a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(jsonOf(BigDecimal(1, -scaleLimit)))
+  }
+
   test("writes what play-json writes, even where play-json cannot read it back") {
     // play-json's serializer and its parser disagree about how to count the digits of a number
     // this long, so play-json rejects its own output here; byte parity means inheriting that

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
@@ -3,15 +3,7 @@ package com.evolution.playjson.jsoniter
 import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, JsonWriterException, writeToString}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import play.api.libs.json.{
-  BigDecimalSerializerConfig,
-  JsNumber,
-  JsObject,
-  JsValue,
-  Json,
-  JsonConfig,
-  JsonValueCodecJsValue
-}
+import play.api.libs.json._
 
 import java.math.MathContext
 import scala.util.Success
@@ -108,8 +100,8 @@ class JsoniterBigDecimalRoundTripSpec extends AnyFunSuite with Matchers {
   test("drops the scale of a value whose trailing zeros are stripped") {
     // the round trip is by value, not by scale: play-json writes "100" for either of these
     new String(PlayJsonJsoniter.serialize(jsonOf(BigDecimal("100.00"))), "UTF-8") shouldEqual """{"amount":100}"""
-    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(jsonOf(BigDecimal("100.00")))).get shouldEqual
-      jsonOf(BigDecimal("100"))
+    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(jsonOf(BigDecimal("100.00")))) shouldEqual
+      Success(jsonOf(BigDecimal("100")))
   }
 
   test("keeps one decimal place when the serializer settings preserve it") {
@@ -128,6 +120,6 @@ class JsoniterBigDecimalRoundTripSpec extends AnyFunSuite with Matchers {
     val rounded = beyondDecimal128.round(MathContext.DECIMAL128)
 
     PlayJsonJsoniter.deserialize(bytes) shouldEqual Success(jsonOf(rounded))
-    PlayJsonJsoniter.deserialize(bytes).get shouldEqual Json.parse(bytes)
+    PlayJsonJsoniter.deserialize(bytes) shouldEqual Success(Json.parse(bytes))
   }
 }

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
 import java.math.MathContext
+import java.nio.charset.StandardCharsets
 import scala.util.Success
 
 /**
@@ -49,8 +50,8 @@ class JsoniterBigDecimalRoundTripSpec extends AnyFunSuite with Matchers {
 
   private def assertParityWithPlayJson(value: BigDecimal): Unit = {
     val jsValue = jsonOf(value)
-    new String(PlayJsonJsoniter.serialize(jsValue), "UTF-8") shouldEqual
-      new String(Json.toBytes(jsValue), "UTF-8")
+    new String(PlayJsonJsoniter.serialize(jsValue), StandardCharsets.UTF_8) shouldEqual
+      new String(Json.toBytes(jsValue), StandardCharsets.UTF_8)
     ()
   }
 
@@ -128,14 +129,16 @@ class JsoniterBigDecimalRoundTripSpec extends AnyFunSuite with Matchers {
     val borderline = BigDecimal("-0.0" + "3" * 307)
     val bytes = PlayJsonJsoniter.serialize(jsonOf(borderline))
 
-    new String(bytes, "UTF-8") shouldEqual new String(Json.toBytes(jsonOf(borderline)), "UTF-8")
+    new String(bytes, StandardCharsets.UTF_8) shouldEqual
+      new String(Json.toBytes(jsonOf(borderline)), StandardCharsets.UTF_8)
     PlayJsonJsoniter.deserialize(bytes) shouldEqual Success(jsonOf(borderline.round(MathContext.DECIMAL128)))
     a[RuntimeException] should be thrownBy Json.parse(bytes)
   }
 
   test("drops the scale of a value whose trailing zeros are stripped") {
     // the round trip is by value, not by scale: play-json writes "100" for either of these
-    new String(PlayJsonJsoniter.serialize(jsonOf(BigDecimal("100.00"))), "UTF-8") shouldEqual """{"amount":100}"""
+    new String(PlayJsonJsoniter.serialize(jsonOf(BigDecimal("100.00"))), StandardCharsets.UTF_8) shouldEqual
+      """{"amount":100}"""
     PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(jsonOf(BigDecimal("100.00")))) shouldEqual
       Success(jsonOf(BigDecimal("100")))
   }

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
@@ -1,9 +1,17 @@
 package com.evolution.playjson.jsoniter
 
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriterException
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, JsonWriterException, writeToString}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import play.api.libs.json.{JsNumber, JsObject, Json}
+import play.api.libs.json.{
+  BigDecimalSerializerConfig,
+  JsNumber,
+  JsObject,
+  JsValue,
+  Json,
+  JsonConfig,
+  JsonValueCodecJsValue
+}
 
 import java.math.MathContext
 import scala.util.Success
@@ -13,7 +21,7 @@ import scala.util.Success
  *
  * The contract is behavior parity with play-json plus round-trip consistency:
  *
- *   - serialization produces the same bytes as play-json's own serializer: trailing zeros are
+ *   - serialization produces the same bytes as play-json's own JVM serializer: trailing zeros are
  *     stripped and values outside `[minPlain, maxPlain]` of
  *     `JsonConfig.settings.bigDecimalSerializerConfig` are written in scientific notation.
  *   - every value the codec serializes it can also deserialize under the limits of
@@ -84,6 +92,35 @@ class JsoniterBigDecimalRoundTripSpec extends AnyFunSuite with Matchers {
     a[JsonWriterException] should be thrownBy {
       PlayJsonJsoniter.serialize(jsonOf(beyondScaleLimit))
     }
+  }
+
+  test("writes what play-json writes, even where play-json cannot read it back") {
+    // play-json's serializer and its parser disagree about how to count the digits of a number
+    // this long, so play-json rejects its own output here; byte parity means inheriting that
+    val borderline = BigDecimal("-0.0" + "3" * 307)
+    val bytes = PlayJsonJsoniter.serialize(jsonOf(borderline))
+
+    new String(bytes, "UTF-8") shouldEqual new String(Json.toBytes(jsonOf(borderline)), "UTF-8")
+    PlayJsonJsoniter.deserialize(bytes) shouldEqual Success(jsonOf(borderline.round(MathContext.DECIMAL128)))
+    a[RuntimeException] should be thrownBy Json.parse(bytes)
+  }
+
+  test("drops the scale of a value whose trailing zeros are stripped") {
+    // the round trip is by value, not by scale: play-json writes "100" for either of these
+    new String(PlayJsonJsoniter.serialize(jsonOf(BigDecimal("100.00"))), "UTF-8") shouldEqual """{"amount":100}"""
+    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(jsonOf(BigDecimal("100.00")))).get shouldEqual
+      jsonOf(BigDecimal("100"))
+  }
+
+  test("keeps one decimal place when the serializer settings preserve it") {
+    val settings = BigDecimalSerializerConfig(
+      minPlain = JsonConfig.settings.bigDecimalSerializerConfig.minPlain,
+      maxPlain = JsonConfig.settings.bigDecimalSerializerConfig.maxPlain,
+      preserveZeroDecimal = true)
+    implicit val codec: JsonValueCodec[JsValue] =
+      JsonValueCodecJsValue(JsonConfig.settings.bigDecimalParseConfig, settings)
+
+    writeToString[JsValue](jsonOf(BigDecimal("100.00"))) shouldEqual """{"amount":100.0}"""
   }
 
   test("reads high-precision values with DECIMAL128 rounding, same as play-json") {

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterBigDecimalRoundTripSpec.scala
@@ -1,0 +1,96 @@
+package com.evolution.playjson.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriterException
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsNumber, JsObject, Json}
+
+import java.math.MathContext
+import scala.util.Success
+
+/**
+ * Contract tests for the BigDecimal handling of [[PlayJsonJsoniter]].
+ *
+ * The contract is behavior parity with play-json plus round-trip consistency:
+ *
+ *   - serialization produces the same bytes as play-json's own serializer: trailing zeros are
+ *     stripped and values outside `[minPlain, maxPlain]` of
+ *     `JsonConfig.settings.bigDecimalSerializerConfig` are written in scientific notation.
+ *   - every value the codec serializes it can also deserialize under the limits of
+ *     `JsonConfig.settings.bigDecimalParseConfig` (digitsLimit, scaleLimit), when no
+ *     representation of a value fits those limits, serialization fails fast instead of
+ *     producing bytes that cannot be read back.
+ *   - reading applies `MathContext.DECIMAL128` exactly like play-json, so values with more
+ *     than 34 significant digits deserialize to their rounded form.
+ */
+class JsoniterBigDecimalRoundTripSpec extends AnyFunSuite with Matchers {
+
+  // one significant digit, but 313 plain characters once scale is 2, must be written as "1E+309"
+  private val oneDigitLargeMagnitude = BigDecimal("1e309").setScale(2)
+
+  // all 312 digits significant: no representation fits digitsLimit (310)
+  private val beyondDigitsLimit = BigDecimal("9" * 310 + ".25")
+
+  // 41 significant digits: within write limits, rounded to DECIMAL128 (34 digits) on read
+  private val beyondDecimal128 = BigDecimal("1." + "1" * 40)
+
+  // 7 characters in scientific notation, but scale 7000 exceeds scaleLimit (6178) on read
+  private val beyondScaleLimit = BigDecimal("1E-7000")
+
+  private def jsonOf(value: BigDecimal): JsObject =
+    JsObject(Map("amount" -> JsNumber(value)))
+
+  private def roundTrip(value: BigDecimal): Unit = {
+    val jsValue = jsonOf(value)
+    val bytes = PlayJsonJsoniter.serialize(jsValue)
+    PlayJsonJsoniter.deserialize(bytes) shouldEqual Success(jsValue)
+    ()
+  }
+
+  private def assertParityWithPlayJson(value: BigDecimal): Unit = {
+    val jsValue = jsonOf(value)
+    new String(PlayJsonJsoniter.serialize(jsValue), "UTF-8") shouldEqual
+      new String(Json.toBytes(jsValue), "UTF-8")
+    ()
+  }
+
+  test("round-trips a plain value") {
+    roundTrip(BigDecimal("123.45"))
+  }
+
+  test("round-trips a one-significant-digit value of large magnitude") {
+    roundTrip(oneDigitLargeMagnitude)
+  }
+
+  test("serializes plain values identically to play-json") {
+    assertParityWithPlayJson(BigDecimal("123.45"))
+  }
+
+  test("serializes values with trailing zeros identically to play-json") {
+    assertParityWithPlayJson(BigDecimal("100.00"))
+  }
+
+  test("serializes large-magnitude values identically to play-json") {
+    assertParityWithPlayJson(oneDigitLargeMagnitude)
+  }
+
+  test("rejects serialization when no representation fits the read digits limit") {
+    a[JsonWriterException] should be thrownBy {
+      PlayJsonJsoniter.serialize(jsonOf(beyondDigitsLimit))
+    }
+  }
+
+  test("rejects serialization when the scale exceeds the read scale limit") {
+    a[JsonWriterException] should be thrownBy {
+      PlayJsonJsoniter.serialize(jsonOf(beyondScaleLimit))
+    }
+  }
+
+  test("reads high-precision values with DECIMAL128 rounding, same as play-json") {
+    val bytes = PlayJsonJsoniter.serialize(jsonOf(beyondDecimal128))
+    val rounded = beyondDecimal128.round(MathContext.DECIMAL128)
+
+    PlayJsonJsoniter.deserialize(bytes) shouldEqual Success(jsonOf(rounded))
+    PlayJsonJsoniter.deserialize(bytes).get shouldEqual Json.parse(bytes)
+  }
+}

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterPlayJsonParitySpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterPlayJsonParitySpec.scala
@@ -1,0 +1,36 @@
+package com.evolution.playjson.jsoniter
+
+import TestData.DataLine
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsSuccess, Json}
+
+/**
+ * Covers the direction [[JsoniterSpec]] does not: documents written by this codec and read by
+ * play-json.
+ *
+ * JVM only on purpose. play-json's Scala.js backend writes numbers as `toString`, without the
+ * trailing-zero stripping and plain-range handling of its JVM serializer, so byte parity is a
+ * claim about the JVM alone.
+ */
+class JsoniterPlayJsonParitySpec extends AnyFunSuite with Matchers {
+
+  private def dataLine: DataLine =
+    Json
+      .fromJson[DataLine](Json.parse(TestData.jsonBody))
+      .fold(errs => throw new Exception(s"Parsing error: ${errs.mkString(",")}"), identity)
+
+  test("Write using Jsoniter and PlayJson: Compare bytes") {
+    val jsValue = Json.toJson(dataLine)
+    val bts = PlayJsonJsoniter.serialize(jsValue)
+
+    new String(bts, "UTF-8") shouldEqual new String(Json.toBytes(jsValue), "UTF-8")
+  }
+
+  test("Write using Jsoniter -> Read using PlayJson: Compare objects") {
+    val expected = dataLine
+    val bts = PlayJsonJsoniter.serialize(Json.toJson(expected))
+
+    Json.fromJson[DataLine](Json.parse(bts)) shouldEqual JsSuccess(expected)
+  }
+}

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterPlayJsonParitySpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsoniterPlayJsonParitySpec.scala
@@ -5,6 +5,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsSuccess, Json}
 
+import java.nio.charset.StandardCharsets
+
 /**
  * Covers the direction [[JsoniterSpec]] does not: documents written by this codec and read by
  * play-json.
@@ -24,7 +26,7 @@ class JsoniterPlayJsonParitySpec extends AnyFunSuite with Matchers {
     val jsValue = Json.toJson(dataLine)
     val bts = PlayJsonJsoniter.serialize(jsValue)
 
-    new String(bts, "UTF-8") shouldEqual new String(Json.toBytes(jsValue), "UTF-8")
+    new String(bts, StandardCharsets.UTF_8) shouldEqual new String(Json.toBytes(jsValue), StandardCharsets.UTF_8)
   }
 
   test("Write using Jsoniter -> Read using PlayJson: Compare objects") {

--- a/play-json-jsoniter/shared/src/main/scala/com/evolution/playjson/jsoniter/PlayJsonJsoniter.scala
+++ b/play-json-jsoniter/shared/src/main/scala/com/evolution/playjson/jsoniter/PlayJsonJsoniter.scala
@@ -11,7 +11,7 @@ import scala.util.Try
 object PlayJsonJsoniter {
   implicit val jsValueCodec: JsonValueCodec[JsValue] = {
     val settings = JsonConfig.settings
-    JsonValueCodecJsValue(settings.bigDecimalParseConfig)
+    JsonValueCodecJsValue(settings.bigDecimalParseConfig, settings.bigDecimalSerializerConfig)
   }
   implicit val durationFormat: Format[Duration] =
     Formats.smallAsciiStringFormat[Duration]("Period", _.readDuration(_), _.writeVal(_))
@@ -38,15 +38,30 @@ object PlayJsonJsoniter {
   implicit val zonedDateTimeFormat: Format[ZonedDateTime] =
     Formats.smallAsciiStringFormat[ZonedDateTime]("ZonedDateTime", _.readZonedDateTime(_), _.writeVal(_))
 
+  /**
+    * Throws `JsonWriterException` for a number that could not be read back, see
+    * [[play.api.libs.json.JsonValueCodecJsValue]].
+    */
   def serialize(payload: JsValue): Array[Byte] =
     writeToArray(payload)
 
+  /** Throws `JsonWriterException` for a number that could not be read back, see [[serialize]]. */
   def serializeToStr(payload: JsValue): String =
     writeToString(payload)
 
+  /**
+    * Throws `JsonWriterException` for a number that could not be read back, see [[serialize]].
+    * The failure is raised where the number is reached, so `bbuf` is left holding the part of the
+    * document written up to that point.
+    */
   def serializeToBuffer(payload: JsValue, bbuf: ByteBuffer): Unit =
      writeToByteBuffer(payload, bbuf)
 
+  /**
+    * Throws `JsonWriterException` for a number that could not be read back, see [[serialize]].
+    * The failure is raised where the number is reached, and the writer flushes as its buffer
+    * fills, so `out` may already have received an incomplete document.
+    */
   def serializeToOutput(payload: JsValue, out: OutputStream): Unit =
     writeToStream(payload, out)
 

--- a/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
+++ b/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
@@ -2,12 +2,33 @@ package play.api.libs.json
 
 import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonValueCodec, JsonWriter}
 
+import java.math.{BigDecimal => JavaBigDecimal}
+import java.nio.charset.StandardCharsets
+import scala.annotation.tailrec
+
 /**
   * INTERNAL API: It is an internal implementation for [[com.evolution.playjson.jsoniter.PlayJsonJsoniter]]`.
+  *
+  * Numbers are written as play-json's own JVM serializer writes them: trailing zeros stripped, and
+  * scientific notation outside `[minPlain, maxPlain]` of the `BigDecimalSerializerConfig`. A number
+  * that `decodeValue` could not read back under the `BigDecimalParseConfig` limits is refused with
+  * `encodeError` rather than written, so the codec never produces a document it cannot parse. The
+  * refusal happens where the number sits in the document, so a writer that streams its buffer may
+  * already have emitted the part before it.
   */
 object JsonValueCodecJsValue {
 
+  @deprecated(
+    "Reading settings are given here, writing settings are taken from the global " +
+      "JsonConfig.settings. Pass both explicitly instead.",
+    "1.4.0")
   def apply(bigDecimalParseSettings: BigDecimalParseConfig): JsonValueCodec[JsValue] =
+    apply(bigDecimalParseSettings, JsonConfig.settings.bigDecimalSerializerConfig)
+
+  def apply(
+    bigDecimalParseSettings: BigDecimalParseConfig,
+    bigDecimalSerializerSettings: BigDecimalSerializerConfig
+  ): JsonValueCodec[JsValue] =
     new JsonValueCodec[JsValue] {
       def decodeValue(in: JsonReader, default: JsValue): JsValue = {
         val b = in.nextToken()
@@ -66,7 +87,7 @@ object JsonValueCodecJsValue {
           case b: JsBoolean =>
             out.writeVal(b.value)
           case n: JsNumber =>
-            out.writeVal(n.value)
+            encodeBigDecimal(n.value, out)
           case a: JsArray =>
             out.writeArrayStart()
             a.value.foreach(encodeValue(_, out))
@@ -80,6 +101,61 @@ object JsonValueCodecJsValue {
             out.writeObjectEnd()
           case _ =>
             out.writeNull()
+        }
+
+      private def encodeBigDecimal(value: BigDecimal, out: JsonWriter): Unit = {
+        val stripped = stripTrailingZeros(value.bigDecimal)
+        val absolute = value.abs
+        val writePlain =
+          absolute > bigDecimalSerializerSettings.minPlain && absolute < bigDecimalSerializerSettings.maxPlain
+        // play-json renders the plain string back through Jackson, which writes any number as
+        // `BigDecimal.toString`, so staying within the plain range only normalizes a negative scale
+        val written = if (writePlain) stripped.setScale(Math.max(stripped.scale, 0)) else stripped
+
+        // a scale of zero renders as the digits of the unscaled value alone, which jsoniter can
+        // write straight into its buffer, and which is always within both parse limits
+        if (written.scale == 0 && written.precision <= 18) out.writeVal(written.unscaledValue.longValue)
+        else {
+          val raw = written.toString
+
+          val digits = countDigits(raw)
+          if (digits >= bigDecimalParseSettings.digitsLimit) {
+            out.encodeError(
+              s"number of digits $digits exceeds the parse limit of ${bigDecimalParseSettings.digitsLimit}")
+          }
+
+          val mathContext = bigDecimalParseSettings.mathContext
+          val readBack = if (mathContext.getPrecision < digits) written.plus(mathContext) else written
+          if (Math.abs(readBack.scale) >= bigDecimalParseSettings.scaleLimit) {
+            out.encodeError(
+              s"scale ${readBack.scale} exceeds the parse limit of ${bigDecimalParseSettings.scaleLimit}")
+          }
+
+          out.writeRawVal(raw.getBytes(StandardCharsets.US_ASCII))
+        }
+      }
+
+      private def stripTrailingZeros(value: JavaBigDecimal): JavaBigDecimal = {
+        val stripped = value.stripTrailingZeros
+        if (bigDecimalSerializerSettings.preserveZeroDecimal && value.scale > 0 && stripped.scale <= 0) {
+          stripped.setScale(1)
+        } else stripped
+      }
+
+      /**
+        * Counts digits the way `JsonReader` counts them while parsing, which is every digit of the
+        * integer and fraction parts and none of the exponent. Leading and trailing zeros count too,
+        * so `0.00000000015` is twelve digits rather than two — that is what makes the count
+        * comparable to `digitsLimit`. `raw` comes from `BigDecimal.toString`, which separates the
+        * exponent with an upper case `E`.
+        */
+      @tailrec
+      private def countDigits(raw: String, index: Int = 0, digits: Int = 0): Int =
+        if (index == raw.length) digits
+        else {
+          val char = raw.charAt(index)
+          if (char == 'E') digits
+          else countDigits(raw, index + 1, if (char >= '0' && char <= '9') digits + 1 else digits)
         }
 
       val nullValue: JsValue = JsNull

--- a/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
+++ b/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
@@ -18,6 +18,13 @@ import scala.annotation.tailrec
   */
 object JsonValueCodecJsValue {
 
+  // A value of at most this many significant digits, written plainly, spans magnitudes from
+  // 1e-6 up to (but not including) 1e18, and takes at most 24 digits to write.
+  private val FastPathMostSignificantDigits = 18
+  private val FastPathMostDigits = 24
+  private val FastPathSmallestValue = BigDecimal("1e-6")
+  private val FastPathLargestValue = BigDecimal("1e18")
+
   @deprecated(
     "Reading settings are given here, writing settings are taken from the global " +
       "JsonConfig.settings. Pass both explicitly instead.",
@@ -103,17 +110,60 @@ object JsonValueCodecJsValue {
             out.writeNull()
         }
 
+      /**
+        * Whether the configured settings are wide enough for [[needsNoNormalization]] to imply
+        * play-json parity. Computed once: the reasoning there is about magnitudes and digit counts,
+        * and only holds while the plain range and the parse limits contain them.
+        */
+      private val fastPathAgreesWithPlayJson: Boolean =
+        bigDecimalSerializerSettings.minPlain < FastPathSmallestValue &&
+          bigDecimalSerializerSettings.maxPlain >= FastPathLargestValue &&
+          bigDecimalParseSettings.digitsLimit > FastPathMostDigits &&
+          bigDecimalParseSettings.scaleLimit > FastPathMostDigits
+
       private def encodeBigDecimal(value: BigDecimal, out: JsonWriter): Unit = {
-        val stripped = stripTrailingZeros(value.bigDecimal)
-        val absolute = value.abs
+        val decimal = value.bigDecimal
+        if (fastPathAgreesWithPlayJson && isSmallWholeNumber(decimal)) out.writeVal(decimal.longValueExact)
+        else if (fastPathAgreesWithPlayJson && needsNoNormalization(decimal)) out.writeVal(value)
+        else encodeNormalizedBigDecimal(decimal, value.abs, out)
+      }
+
+      /**
+        * Whether the value is a whole number play-json would write as plain digits, which is what
+        * writing the unscaled value as a `Long` produces. Trailing zeros make no difference here:
+        * stripping them only turns the scale negative, and the plain range turns it straight back.
+        */
+      private def isSmallWholeNumber(decimal: JavaBigDecimal): Boolean =
+        decimal.scale == 0 && decimal.precision <= FastPathMostSignificantDigits
+
+      /**
+        * Whether jsoniter's own `BigDecimal` writer already produces what play-json would, which
+        * spares the value the normalization and limit checks below.
+        *
+        * Everything in this range renders plain — `scale <= precision + 5` is Java's rule for not
+        * switching to an exponent — and magnitudes between 1e-6 and 1e18 sit inside the plain range
+        * play-json writes plainly, so both write the same digits. Trailing zeros are the one thing
+        * that would make them differ, and the unscaled value ending in a zero is what betrays them.
+        */
+      private def needsNoNormalization(decimal: JavaBigDecimal): Boolean = {
+        val scale = decimal.scale
+        scale > 0 && decimal.precision <= FastPathMostSignificantDigits &&
+        scale <= decimal.precision + 5 &&
+        decimal.unscaledValue.longValue % 10 != 0
+      }
+
+      private def encodeNormalizedBigDecimal(
+        decimal: JavaBigDecimal,
+        absolute: BigDecimal,
+        out: JsonWriter
+      ): Unit = {
+        val stripped = stripTrailingZeros(decimal)
         val writePlain =
           absolute > bigDecimalSerializerSettings.minPlain && absolute < bigDecimalSerializerSettings.maxPlain
         // play-json renders the plain string back through Jackson, which writes any number as
         // `BigDecimal.toString`, so staying within the plain range only normalizes a negative scale
         val written = if (writePlain) stripped.setScale(Math.max(stripped.scale, 0)) else stripped
 
-        // a scale of zero renders as the digits of the unscaled value alone, which jsoniter can
-        // write straight into its buffer, and which is always within both parse limits
         if (written.scale == 0 && written.precision <= 18) out.writeVal(written.unscaledValue.longValue)
         else {
           val raw = written.toString

--- a/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JsoniterSpec.scala
+++ b/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JsoniterSpec.scala
@@ -21,7 +21,7 @@ class JsoniterSpec extends AnyFunSuite with Matchers {
     val jsValue = Json.toJson(expected)
     val bts0 = PlayJsonJsoniter.serialize(jsValue)
     val bts1 = Json.toBytes(jsValue)
-    new String(bts0, "UTF-8") shouldEqual new String(bts1, "UTF-8")
+    new String(bts0, StandardCharsets.UTF_8) shouldEqual new String(bts1, StandardCharsets.UTF_8)
   }
 
   test("Write using PlayJson -> Read using Jsoniter: Compare objects") {

--- a/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JsoniterSpec.scala
+++ b/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JsoniterSpec.scala
@@ -32,6 +32,21 @@ class JsoniterSpec extends AnyFunSuite with Matchers {
     Success(JsSuccess(expected)) shouldEqual jsValue
   }
 
+  test("Write using Jsoniter and PlayJson: Compare bytes") {
+    val expected: DataLine = Json.fromJson[DataLine](Json.parse(TestData.jsonBody))
+      .fold(errs => throw new Exception(s"Parsing error: ${errs.mkString(",")}"), identity)
+    val jsValue = Json.toJson(expected)
+    val bts = PlayJsonJsoniter.serialize(jsValue)
+    new String(bts, "UTF-8") shouldEqual new String(Json.toBytes(jsValue), "UTF-8")
+  }
+
+  test("Write using Jsoniter -> Read using PlayJson: Compare objects") {
+    val expected: DataLine = Json.fromJson[DataLine](Json.parse(TestData.jsonBody))
+      .fold(errs => throw new Exception(s"Parsing error: ${errs.mkString(",")}"), identity)
+    val bts = PlayJsonJsoniter.serialize(Json.toJson(expected))
+    Json.fromJson[DataLine](Json.parse(bts)) shouldEqual JsSuccess(expected)
+  }
+
   test("Can write/read large number by play-json") {
     //when number size hits length 35, equality comparison doesn't work anymore
     val largeNum = "9999999999999999999999999999999911"

--- a/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JsoniterSpec.scala
+++ b/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JsoniterSpec.scala
@@ -32,21 +32,6 @@ class JsoniterSpec extends AnyFunSuite with Matchers {
     Success(JsSuccess(expected)) shouldEqual jsValue
   }
 
-  test("Write using Jsoniter and PlayJson: Compare bytes") {
-    val expected: DataLine = Json.fromJson[DataLine](Json.parse(TestData.jsonBody))
-      .fold(errs => throw new Exception(s"Parsing error: ${errs.mkString(",")}"), identity)
-    val jsValue = Json.toJson(expected)
-    val bts = PlayJsonJsoniter.serialize(jsValue)
-    new String(bts, "UTF-8") shouldEqual new String(Json.toBytes(jsValue), "UTF-8")
-  }
-
-  test("Write using Jsoniter -> Read using PlayJson: Compare objects") {
-    val expected: DataLine = Json.fromJson[DataLine](Json.parse(TestData.jsonBody))
-      .fold(errs => throw new Exception(s"Parsing error: ${errs.mkString(",")}"), identity)
-    val bts = PlayJsonJsoniter.serialize(Json.toJson(expected))
-    Json.fromJson[DataLine](Json.parse(bts)) shouldEqual JsSuccess(expected)
-  }
-
   test("Can write/read large number by play-json") {
     //when number size hits length 35, equality comparison doesn't work anymore
     val largeNum = "9999999999999999999999999999999911"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")


### PR DESCRIPTION
The jsoniter codec enforced play-json's parse limits when reading but wrote numbers without any of play-json's serialization rules. Two consequences: the two backends produced different bytes for the same JsValue, so a document written through one and read by the other could not be compared or reproduced, and some values serialized into output that the codec itself could no longer read, meaning a payload could be written successfully and then fail to parse on the way back.

Numbers are now written exactly as play-json writes them, and a value that could not be read back is rejected at write time rather than silently turning into unusable output.

Two things for reviewers to be aware of:

- Serialized bytes change for numbers carrying trailing zeros — 100.00 is now written as 100. Values are preserved, scale is not. Anyone comparing JSON strings or hashing payloads will see a difference.
- The codec had no test covering the direction where jsoniter writes and play-json reads, so writer divergence was invisible. That direction is now covered, which is what caught the remaining mismatch.
- A JMH module is included so changes like this can be measured. Writing whole numbers got faster, values that need normalization got slower. Figures are in benchmark/README.md.