### PR TITLE
Correct type names and a writable Year in play-json-jsoniter

### DIFF
--- a/play-json-jsoniter/shared/src/main/scala/com/evolution/playjson/jsoniter/PlayJsonJsoniter.scala
+++ b/play-json-jsoniter/shared/src/main/scala/com/evolution/playjson/jsoniter/PlayJsonJsoniter.scala
@@ -14,9 +14,9 @@ object PlayJsonJsoniter {
     JsonValueCodecJsValue(settings.bigDecimalParseConfig)
   }
   implicit val durationFormat: Format[Duration] =
-    Formats.smallAsciiStringFormat[Duration]("Period", _.readDuration(_), _.writeVal(_))
+    Formats.smallAsciiStringFormat[Duration]("Duration", _.readDuration(_), _.writeVal(_))
   implicit val instantFormat: Format[Instant] =
-    Formats.smallAsciiStringFormat[Instant]("Period", _.readInstant(_), _.writeVal(_))
+    Formats.smallAsciiStringFormat[Instant]("Instant", _.readInstant(_), _.writeVal(_))
   implicit val localDateFormat: Format[LocalDate] =
     Formats.smallAsciiStringFormat[LocalDate]("LocalDate", _.readLocalDate(_), _.writeVal(_))
   implicit val localDateTimeFormat: Format[LocalDateTime] =
@@ -31,8 +31,14 @@ object PlayJsonJsoniter {
     Formats.smallAsciiStringFormat[OffsetTime]("OffsetTime", _.readOffsetTime(_), _.writeVal(_))
   implicit val periodFormat: Format[Period] =
     Formats.smallAsciiStringFormat[Period]("Period", _.readPeriod(_), _.writeVal(_))
-  implicit val yearFormat: Reads[Year] =
+  implicit val yearJsonFormat: Format[Year] =
     Formats.smallAsciiStringFormat[Year]("Year", _.readYear(_), _.writeVal(_))
+  // `Year` was the only type here exposed as a `Reads`, so the implicit had to move to a new name:
+  // widening this one to `Format` would change its erased result type and break linkage for code
+  // compiled against 1.3.x. It is no longer implicit, which costs no binary compatibility, and can
+  // be dropped at the next major bump.
+  @deprecated("Use yearJsonFormat, which can write as well as read", "1.4.0")
+  val yearFormat: Reads[Year] = yearJsonFormat
   implicit val yearMonthFormat: Format[YearMonth] =
     Formats.smallAsciiStringFormat[YearMonth]("YearMonth", _.readYearMonth(_), _.writeVal(_))
   implicit val zonedDateTimeFormat: Format[ZonedDateTime] =

--- a/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JavaTimeFormatsSpec.scala
+++ b/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JavaTimeFormatsSpec.scala
@@ -2,59 +2,65 @@ package com.evolution.playjson.jsoniter
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import play.api.libs.json.{Format, JsError, JsNumber, JsString, JsSuccess, Reads}
+import play.api.libs.json.{Format, JsError, JsNumber, JsString, JsSuccess}
 
 import java.time._
 
 /**
-  * Contract tests for the java.time formats of [[PlayJsonJsoniter]]: every format writes a value
-  * that it can read back, and a value it cannot read is reported against the name of the type it
-  * was asked to read.
+  * Contract tests for the java.time formats of [[PlayJsonJsoniter]]: every format writes a value in
+  * a pinned form and reads it back, and a value it cannot read is reported against the name of the
+  * type it was asked to read.
   */
 class JavaTimeFormatsSpec extends AnyFunSuite with Matchers {
 
   import PlayJsonJsoniter._
 
-  private def assertRoundTrip[A](value: A)(implicit format: Format[A]): Unit = {
-    format.reads(format.writes(value)) shouldEqual JsSuccess(value)
+  private def assertContract[A](name: String, value: A, written: String)(implicit format: Format[A]): Unit = {
+    assertRoundTrip(value, written)(format)
+    assertReadErrorNames(name, written)(format)
+  }
+
+  /**
+    * Pins the written form as well as the round trip: a change of codec that still round-tripped
+    * would go unnoticed otherwise, and the written form is what every other reader of the wire sees.
+    */
+  private def assertRoundTrip[A](value: A, written: String)(implicit format: Format[A]): Unit = {
+    format.writes(value) shouldEqual JsString(written)
+    format.reads(JsString(written)) shouldEqual JsSuccess(value)
     ()
   }
 
-  private def assertReadErrorNames[A](name: String)(implicit reads: Reads[A]): Unit = {
-    reads.reads(JsString("not a " + name)) shouldEqual JsError(name)
-    reads.reads(JsNumber(1)) shouldEqual JsError(name)
+  private def assertReadErrorNames[A](name: String, written: String)(implicit format: Format[A]): Unit = {
+    format.reads(JsString("not a " + name)) shouldEqual JsError(name)
+    format.reads(JsNumber(1)) shouldEqual JsError(name)
+    format.reads(JsString(aboveAscii(written))) shouldEqual JsError(name)
     ()
   }
 
-  test("Duration round-trips") { assertRoundTrip(Duration.ofSeconds(90)) }
-  test("Instant round-trips") { assertRoundTrip(Instant.parse("2026-08-03T10:15:30Z")) }
-  test("LocalDate round-trips") { assertRoundTrip(LocalDate.of(2026, 8, 3)) }
-  test("LocalDateTime round-trips") { assertRoundTrip(LocalDateTime.of(2026, 8, 3, 10, 15, 30)) }
-  test("LocalTime round-trips") { assertRoundTrip(LocalTime.of(10, 15, 30)) }
-  test("MonthDay round-trips") { assertRoundTrip(MonthDay.of(8, 3)) }
-  test("OffsetDateTime round-trips") { assertRoundTrip(OffsetDateTime.parse("2026-08-03T10:15:30+02:00")) }
-  test("OffsetTime round-trips") { assertRoundTrip(OffsetTime.parse("10:15:30+02:00")) }
-  test("Period round-trips") { assertRoundTrip(Period.ofDays(3)) }
-  test("Year round-trips") { assertRoundTrip(Year.of(2026)) }
-  test("YearMonth round-trips") { assertRoundTrip(YearMonth.of(2026, 8)) }
-  test("ZonedDateTime round-trips") { assertRoundTrip(ZonedDateTime.parse("2026-08-03T10:15:30+02:00")) }
+  /**
+    * The written form with every character moved out of ASCII, its low byte unchanged. The reader
+    * narrows a character at a time into a byte buffer, so these would read back as the value they
+    * were derived from if it did not check the high bits itself.
+    */
+  private def aboveAscii(written: String): String =
+    written.map(character => (character + 0x100).toChar)
 
-  test("Duration reports its own type name when it cannot read") { assertReadErrorNames[Duration]("Duration") }
-  test("Instant reports its own type name when it cannot read") { assertReadErrorNames[Instant]("Instant") }
-  test("LocalDate reports its own type name when it cannot read") { assertReadErrorNames[LocalDate]("LocalDate") }
-  test("LocalDateTime reports its own type name when it cannot read") {
-    assertReadErrorNames[LocalDateTime]("LocalDateTime")
+  test("Duration") { assertContract("Duration", Duration.ofSeconds(90), "PT1M30S") }
+  test("Instant") { assertContract("Instant", Instant.parse("2026-08-03T10:15:30Z"), "2026-08-03T10:15:30Z") }
+  test("LocalDate") { assertContract("LocalDate", LocalDate.of(2026, 8, 3), "2026-08-03") }
+  test("LocalDateTime") {
+    assertContract("LocalDateTime", LocalDateTime.of(2026, 8, 3, 10, 15, 30), "2026-08-03T10:15:30")
   }
-  test("LocalTime reports its own type name when it cannot read") { assertReadErrorNames[LocalTime]("LocalTime") }
-  test("MonthDay reports its own type name when it cannot read") { assertReadErrorNames[MonthDay]("MonthDay") }
-  test("OffsetDateTime reports its own type name when it cannot read") {
-    assertReadErrorNames[OffsetDateTime]("OffsetDateTime")
+  test("LocalTime") { assertContract("LocalTime", LocalTime.of(10, 15, 30), "10:15:30") }
+  test("MonthDay") { assertContract("MonthDay", MonthDay.of(8, 3), "--08-03") }
+  test("OffsetDateTime") {
+    assertContract("OffsetDateTime", OffsetDateTime.parse("2026-08-03T10:15:30+02:00"), "2026-08-03T10:15:30+02:00")
   }
-  test("OffsetTime reports its own type name when it cannot read") { assertReadErrorNames[OffsetTime]("OffsetTime") }
-  test("Period reports its own type name when it cannot read") { assertReadErrorNames[Period]("Period") }
-  test("Year reports its own type name when it cannot read") { assertReadErrorNames[Year]("Year") }
-  test("YearMonth reports its own type name when it cannot read") { assertReadErrorNames[YearMonth]("YearMonth") }
-  test("ZonedDateTime reports its own type name when it cannot read") {
-    assertReadErrorNames[ZonedDateTime]("ZonedDateTime")
+  test("OffsetTime") { assertContract("OffsetTime", OffsetTime.parse("10:15:30+02:00"), "10:15:30+02:00") }
+  test("Period") { assertContract("Period", Period.ofDays(3), "P3D") }
+  test("Year") { assertContract("Year", Year.of(2026), "2026") }
+  test("YearMonth") { assertContract("YearMonth", YearMonth.of(2026, 8), "2026-08") }
+  test("ZonedDateTime") {
+    assertContract("ZonedDateTime", ZonedDateTime.parse("2026-08-03T10:15:30+02:00"), "2026-08-03T10:15:30+02:00")
   }
 }

--- a/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JavaTimeFormatsSpec.scala
+++ b/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JavaTimeFormatsSpec.scala
@@ -35,6 +35,7 @@ class JavaTimeFormatsSpec extends AnyFunSuite with Matchers {
   test("OffsetDateTime round-trips") { assertRoundTrip(OffsetDateTime.parse("2026-08-03T10:15:30+02:00")) }
   test("OffsetTime round-trips") { assertRoundTrip(OffsetTime.parse("10:15:30+02:00")) }
   test("Period round-trips") { assertRoundTrip(Period.ofDays(3)) }
+  test("Year round-trips") { assertRoundTrip(Year.of(2026)) }
   test("YearMonth round-trips") { assertRoundTrip(YearMonth.of(2026, 8)) }
   test("ZonedDateTime round-trips") { assertRoundTrip(ZonedDateTime.parse("2026-08-03T10:15:30+02:00")) }
 

--- a/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JavaTimeFormatsSpec.scala
+++ b/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JavaTimeFormatsSpec.scala
@@ -1,0 +1,59 @@
+package com.evolution.playjson.jsoniter
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{Format, JsError, JsNumber, JsString, JsSuccess, Reads}
+
+import java.time._
+
+/**
+  * Contract tests for the java.time formats of [[PlayJsonJsoniter]]: every format writes a value
+  * that it can read back, and a value it cannot read is reported against the name of the type it
+  * was asked to read.
+  */
+class JavaTimeFormatsSpec extends AnyFunSuite with Matchers {
+
+  import PlayJsonJsoniter._
+
+  private def assertRoundTrip[A](value: A)(implicit format: Format[A]): Unit = {
+    format.reads(format.writes(value)) shouldEqual JsSuccess(value)
+    ()
+  }
+
+  private def assertReadErrorNames[A](name: String)(implicit reads: Reads[A]): Unit = {
+    reads.reads(JsString("not a " + name)) shouldEqual JsError(name)
+    reads.reads(JsNumber(1)) shouldEqual JsError(name)
+    ()
+  }
+
+  test("Duration round-trips") { assertRoundTrip(Duration.ofSeconds(90)) }
+  test("Instant round-trips") { assertRoundTrip(Instant.parse("2026-08-03T10:15:30Z")) }
+  test("LocalDate round-trips") { assertRoundTrip(LocalDate.of(2026, 8, 3)) }
+  test("LocalDateTime round-trips") { assertRoundTrip(LocalDateTime.of(2026, 8, 3, 10, 15, 30)) }
+  test("LocalTime round-trips") { assertRoundTrip(LocalTime.of(10, 15, 30)) }
+  test("MonthDay round-trips") { assertRoundTrip(MonthDay.of(8, 3)) }
+  test("OffsetDateTime round-trips") { assertRoundTrip(OffsetDateTime.parse("2026-08-03T10:15:30+02:00")) }
+  test("OffsetTime round-trips") { assertRoundTrip(OffsetTime.parse("10:15:30+02:00")) }
+  test("Period round-trips") { assertRoundTrip(Period.ofDays(3)) }
+  test("YearMonth round-trips") { assertRoundTrip(YearMonth.of(2026, 8)) }
+  test("ZonedDateTime round-trips") { assertRoundTrip(ZonedDateTime.parse("2026-08-03T10:15:30+02:00")) }
+
+  test("Duration reports its own type name when it cannot read") { assertReadErrorNames[Duration]("Duration") }
+  test("Instant reports its own type name when it cannot read") { assertReadErrorNames[Instant]("Instant") }
+  test("LocalDate reports its own type name when it cannot read") { assertReadErrorNames[LocalDate]("LocalDate") }
+  test("LocalDateTime reports its own type name when it cannot read") {
+    assertReadErrorNames[LocalDateTime]("LocalDateTime")
+  }
+  test("LocalTime reports its own type name when it cannot read") { assertReadErrorNames[LocalTime]("LocalTime") }
+  test("MonthDay reports its own type name when it cannot read") { assertReadErrorNames[MonthDay]("MonthDay") }
+  test("OffsetDateTime reports its own type name when it cannot read") {
+    assertReadErrorNames[OffsetDateTime]("OffsetDateTime")
+  }
+  test("OffsetTime reports its own type name when it cannot read") { assertReadErrorNames[OffsetTime]("OffsetTime") }
+  test("Period reports its own type name when it cannot read") { assertReadErrorNames[Period]("Period") }
+  test("Year reports its own type name when it cannot read") { assertReadErrorNames[Year]("Year") }
+  test("YearMonth reports its own type name when it cannot read") { assertReadErrorNames[YearMonth]("YearMonth") }
+  test("ZonedDateTime reports its own type name when it cannot read") {
+    assertReadErrorNames[ZonedDateTime]("ZonedDateTime")
+  }
+}

--- a/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JavaTimeFormatsSpec.scala
+++ b/play-json-jsoniter/shared/src/test/scala/com/evolution/playjson/jsoniter/JavaTimeFormatsSpec.scala
@@ -1,5 +1,6 @@
 package com.evolution.playjson.jsoniter
 
+import com.evolution.playjson.jsoniter.PlayJsonJsoniter._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{Format, JsError, JsNumber, JsString, JsSuccess}
@@ -12,8 +13,6 @@ import java.time._
   * type it was asked to read.
   */
 class JavaTimeFormatsSpec extends AnyFunSuite with Matchers {
-
-  import PlayJsonJsoniter._
 
   private def assertContract[A](name: String, value: A, written: String)(implicit format: Format[A]): Unit = {
     assertRoundTrip(value, written)(format)


### PR DESCRIPTION
1. A failed read of a Duration or an Instant reported the error against "Period", so a validation message pointed at a type the caller never mentioned.
2. Year was exposed as a Reads, which meant a value could be read but never written, unlike every other java.time type in this object.

Errors now name the type that was actually being read, and Year can be written.

For reviewers:

- yearFormat keeps its Reads type and is deprecated. The Format arrives as yearJsonFormat, because widening the existing val would change its erased result type and break linkage for anything compiled against 1.3.x. The naming inconsistency is deliberate and the deprecated val can go at the next major bump.
- Nothing covered these formats at all. A contract spec now pins, for all twelve of them, the exact string each value is written as, that the string reads back, and that a failed read names its own type. Pinning the written form matters because these strings are the wire, and round-trip tests alone would accept a change of shape.