### PR TITLE
Malformed values reported instead of thrown in play-json-tools

### DIFF
--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -29,12 +29,15 @@ object PlayJsonHelper {
 
   implicit val FiniteDurationFormat: Format[FiniteDuration] = new Format[FiniteDuration] {
 
-    def reads(json: JsValue) = {
-      def readStr = for {x <- json.validate[String]} yield Duration(x).toCoarsest.asInstanceOf[FiniteDuration]
-
-      def readNum = for {x <- json.validate[Long]} yield x.millis
-
-      readStr orElse readNum
+    // matching the shape first rather than `readStr orElse readNum`: `orElse` drops the errors of
+    // the first branch, so a string that does not parse used to be reported as a missing number
+    def reads(json: JsValue) = json match {
+      case JsString(x) => Try(Duration(x)) match {
+        case Success(x: FiniteDuration) => JsSuccess(x.toCoarsest)
+        case Success(x)                 => JsError(s"$x is not a finite duration")
+        case Failure(t)                 => JsError(t.toString)
+      }
+      case _           => for {x <- json.validate[Long]} yield x.millis
     }
 
     def writes(o: FiniteDuration): JsString = JsString(o.toCoarsest.toString)
@@ -47,16 +50,21 @@ object PlayJsonHelper {
     private val IsoFormat = DateTimeFormatter.ISO_INSTANT
 
     def reads(json: JsValue): JsResult[Instant] = {
-      def readStr = for {x <- json.validate[String]} yield {
-        val temporal = Try { Format.parse(x) } recover { case _: DateTimeParseException => IsoFormat.parse(x) }
-        Instant.from(temporal.get)
+      def parse(x: String) = Try { Format.parse(x) }
+        .recover { case _: DateTimeParseException => IsoFormat.parse(x) }
+        .map(Instant.from)
+
+      // see the note on FiniteDurationFormat.reads for why the shape is matched first
+      json match {
+        case JsString(x) => parse(x) match {
+          case Success(x) => JsSuccess(x)
+          case Failure(t) => JsError(t.toString)
+        }
+        case _           => for {x <- json.validate[Long]} yield Instant.ofEpochMilli(x)
       }
-
-      def readNum = for {x <- json.validate[Long]} yield Instant.ofEpochMilli(x)
-
-      readStr orElse readNum
     }
 
+    /** Writes milliseconds, so any finer precision the instant carries is dropped. */
     def writes(o: Instant): JsValue = JsString(Format.format(o))
   }
 
@@ -68,7 +76,11 @@ object PlayJsonHelper {
     def reads(json: JsValue): JsResult[LocalTime] = {
       for {
         time <- json.validate[String]
-      } yield LocalTime.parse(time, Format)
+        localTime <- Try(LocalTime.parse(time, Format)) match {
+          case Success(x) => JsSuccess(x)
+          case Failure(t) => JsError(t.toString)
+        }
+      } yield localTime
     }
 
     def writes(o: LocalTime): JsValue = JsString(Format.format(o))
@@ -372,6 +384,14 @@ object PlayJsonHelper {
   }
 
 
+  /**
+    * Writes a `Left` as `{"left": ...}` and a `Right` as the bare value, and reads try `left` first.
+    * The two sides therefore collide whenever a `Right` writes an object carrying a readable `left`
+    * field, and the `Right` is the one that loses: for an `Either[String, Map[String, String]]`,
+    * `Right(Map("left" -> "1"))` writes `{"left":"1"}`, exactly what `Left("1")` writes, and reads
+    * back as `Left("1")` with no error. Use [[DiscriminatedEitherFormat.eitherFormat]], which labels
+    * both sides, wherever `R` can produce such an object.
+    */
   implicit def eitherFormat[L, R](implicit lf: Format[L], rf: Format[R]): Format[Either[L, R]] = new Format[Either[L, R]] {
     def writes(x: Either[L, R]): JsValue = x match {
       case Left(x)  => Json.obj("left" -> lf.writes(x))

--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -51,7 +51,10 @@ object PlayJsonHelper {
 
   implicit val InstantFormat: Format[Instant] = new Format[Instant] {
 
-    private val Format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+    // `uuuu` is the year itself, where `yyyy` is the year within the era: with no era in the pattern,
+    // `yyyy` wrote an instant before year 1 as the matching year AD, so 100 BC came back as 101 AD.
+    // The two agree for every instant from year 1 onwards, so only those are written differently
+    private val Format = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
     private val IsoFormat = DateTimeFormatter.ISO_INSTANT
 
     def reads(json: JsValue): JsResult[Instant] = {

--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -37,7 +37,12 @@ object PlayJsonHelper {
         case Success(duration)                 => JsError(s"$duration is not a finite duration")
         case Failure(error)                    => JsError(error.toString)
       }
-      case _                => for {millis <- json.validate[Long]} yield millis.millis
+      case _ => json.validate[Long].flatMap { millis =>
+        Try(millis.millis) match {
+          case Success(duration) => JsSuccess(duration)
+          case Failure(error)    => JsError(error.toString)
+        }
+      }
     }
 
     def writes(o: FiniteDuration): JsString = JsString(o.toCoarsest.toString)

--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -50,7 +50,7 @@ object PlayJsonHelper {
     private val IsoFormat = DateTimeFormatter.ISO_INSTANT
 
     def reads(json: JsValue): JsResult[Instant] = {
-      def parse(string: String) = Try { Format.parse(string) }
+      def parse(string: String) = Try(Format.parse(string))
         .recover { case _: DateTimeParseException => IsoFormat.parse(string) }
         .map(Instant.from)
 
@@ -99,7 +99,7 @@ object PlayJsonHelper {
 
         def reads(json: JsValue) = for {
           a <- json.validate[String]
-          a <- from(a) map { x => JsSuccess(x) } getOrElse JsError(s"No ${ tag.runtimeClass.getName } found for $a")
+          a <- from(a).map(JsSuccess(_)).getOrElse(JsError(s"No ${ tag.runtimeClass.getName } found for $a"))
         } yield a
 
         def writes(a: A): JsString = JsString(to(a))
@@ -116,7 +116,7 @@ object PlayJsonHelper {
 
         def reads(json: JsValue) = for {
           a <- json.validate[BigDecimal]
-          a <- from(a) map { x => JsSuccess(x) } getOrElse JsError(s"No ${ tag.runtimeClass.getName } found for $a")
+          a <- from(a).map(JsSuccess(_)).getOrElse(JsError(s"No ${ tag.runtimeClass.getName } found for $a"))
         } yield a
 
         def writes(x: A): JsNumber = JsNumber(to(x))
@@ -200,7 +200,7 @@ object PlayJsonHelper {
 
     def apply[K, V](toStr: K => String, fromStr: String => K)(implicit vf: Format[V]): OFormat[Map[K, V]] = {
 
-      val format = StringKeyMapFormat[K, V](k => Try { fromStr(k) }.toOption, toStr)
+      val format = StringKeyMapFormat[K, V](k => Try(fromStr(k)).toOption, toStr)
 
       new OFormat[Map[K, V]] {
 
@@ -403,7 +403,7 @@ object PlayJsonHelper {
 
       def right = for {right <- json.validate[R]} yield Right(right)
 
-      left orElse right
+      left.orElse(right)
     }
   }
 

--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -32,12 +32,12 @@ object PlayJsonHelper {
     // matching the shape first rather than `readStr orElse readNum`: `orElse` drops the errors of
     // the first branch, so a string that does not parse used to be reported as a missing number
     def reads(json: JsValue) = json match {
-      case JsString(x) => Try(Duration(x)) match {
-        case Success(x: FiniteDuration) => JsSuccess(x.toCoarsest)
-        case Success(x)                 => JsError(s"$x is not a finite duration")
-        case Failure(t)                 => JsError(t.toString)
+      case JsString(string) => Try(Duration(string)) match {
+        case Success(duration: FiniteDuration) => JsSuccess(duration.toCoarsest)
+        case Success(duration)                 => JsError(s"$duration is not a finite duration")
+        case Failure(error)                    => JsError(error.toString)
       }
-      case _           => for {x <- json.validate[Long]} yield x.millis
+      case _                => for {millis <- json.validate[Long]} yield millis.millis
     }
 
     def writes(o: FiniteDuration): JsString = JsString(o.toCoarsest.toString)
@@ -50,17 +50,17 @@ object PlayJsonHelper {
     private val IsoFormat = DateTimeFormatter.ISO_INSTANT
 
     def reads(json: JsValue): JsResult[Instant] = {
-      def parse(x: String) = Try { Format.parse(x) }
-        .recover { case _: DateTimeParseException => IsoFormat.parse(x) }
+      def parse(string: String) = Try { Format.parse(string) }
+        .recover { case _: DateTimeParseException => IsoFormat.parse(string) }
         .map(Instant.from)
 
       // see the note on FiniteDurationFormat.reads for why the shape is matched first
       json match {
-        case JsString(x) => parse(x) match {
-          case Success(x) => JsSuccess(x)
-          case Failure(t) => JsError(t.toString)
+        case JsString(string) => parse(string) match {
+          case Success(instant) => JsSuccess(instant)
+          case Failure(error)   => JsError(error.toString)
         }
-        case _           => for {x <- json.validate[Long]} yield Instant.ofEpochMilli(x)
+        case _                => for {millis <- json.validate[Long]} yield Instant.ofEpochMilli(millis)
       }
     }
 
@@ -77,8 +77,8 @@ object PlayJsonHelper {
       for {
         time <- json.validate[String]
         localTime <- Try(LocalTime.parse(time, Format)) match {
-          case Success(x) => JsSuccess(x)
-          case Failure(t) => JsError(t.toString)
+          case Success(parsed) => JsSuccess(parsed)
+          case Failure(error)  => JsError(error.toString)
         }
       } yield localTime
     }

--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -54,12 +54,12 @@ object PlayJsonHelper {
     // `uuuu` is the year itself, where `yyyy` is the year within the era: with no era in the pattern,
     // `yyyy` wrote an instant before year 1 as the matching year AD, so 100 BC came back as 101 AD.
     // The two agree for every instant from year 1 onwards, so only those are written differently
-    private val Format = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
-    private val IsoFormat = DateTimeFormatter.ISO_INSTANT
+    private val millisFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+    private val isoFormatter = DateTimeFormatter.ISO_INSTANT
 
     def reads(json: JsValue): JsResult[Instant] = {
-      def parse(string: String) = Try(Format.parse(string))
-        .recover { case _: DateTimeParseException => IsoFormat.parse(string) }
+      def parse(string: String) = Try(millisFormatter.parse(string))
+        .recover { case _: DateTimeParseException => isoFormatter.parse(string) }
         .map(Instant.from)
 
       // see the note on FiniteDurationFormat.reads for why the shape is matched first
@@ -73,25 +73,25 @@ object PlayJsonHelper {
     }
 
     /** Writes milliseconds, so any finer precision the instant carries is dropped. */
-    def writes(o: Instant): JsValue = JsString(Format.format(o))
+    def writes(o: Instant): JsValue = JsString(millisFormatter.format(o))
   }
 
 
   implicit val LocalTimeFormat: Format[LocalTime] = new Format[LocalTime] {
 
-    private val Format = DateTimeFormatter.ofPattern("HH:mm:ss")
+    private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
 
     def reads(json: JsValue): JsResult[LocalTime] = {
       for {
         time <- json.validate[String]
-        localTime <- Try(LocalTime.parse(time, Format)) match {
+        localTime <- Try(LocalTime.parse(time, timeFormatter)) match {
           case Success(parsed) => JsSuccess(parsed)
           case Failure(error)  => JsError(error.toString)
         }
       } yield localTime
     }
 
-    def writes(o: LocalTime): JsValue = JsString(Format.format(o))
+    def writes(o: LocalTime): JsValue = JsString(timeFormatter.format(o))
   }
 
 

--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -385,27 +385,46 @@ object PlayJsonHelper {
 
 
   /**
-    * Writes a `Left` as `{"left": ...}` and a `Right` as the bare value, and reads try `left` first.
-    * The two sides therefore collide whenever a `Right` writes an object carrying a readable `left`
-    * field, and the `Right` is the one that loses: for an `Either[String, Map[String, String]]`,
+    * The `Either` format this object has always supplied, kept behind an explicit opt-in because a
+    * document it writes cannot always be read back as what it was.
+    *
+    * A `Left` is written as `{"left": ...}` and a `Right` as the bare value, and reads try `left`
+    * first. The two collide whenever a `Right` writes an object carrying a readable `left` field, and
+    * the `Right` is the one that loses: for an `Either[String, Map[String, String]]`,
     * `Right(Map("left" -> "1"))` writes `{"left":"1"}`, exactly what `Left("1")` writes, and reads
-    * back as `Left("1")` with no error. Use [[DiscriminatedEitherFormat.eitherFormat]], which labels
-    * both sides, wherever `R` can produce such an object.
+    * back as `Left("1")` with no error.
+    *
+    * [[DiscriminatedEitherFormat.eitherFormat]] labels both sides and has no such case, but it writes
+    * a different document, so moving to it means migrating what is already stored. This one is for
+    * code that has to keep reading the documents it wrote.
     */
-  implicit def eitherFormat[L, R](implicit lf: Format[L], rf: Format[R]): Format[Either[L, R]] = new Format[Either[L, R]] {
-    def writes(x: Either[L, R]): JsValue = x match {
-      case Left(x)  => Json.obj("left" -> lf.writes(x))
-      case Right(x) => rf.writes(x)
-    }
+  object EitherFormatUnsafe {
 
-    def reads(json: JsValue): JsResult[Either[L, R]] = {
-      def left = for {left <- (json \ "left").validate[L]} yield Left(left)
+    implicit def eitherFormat[L, R](implicit lf: Format[L], rf: Format[R]): Format[Either[L, R]] =
+      new Format[Either[L, R]] {
 
-      def right = for {right <- json.validate[R]} yield Right(right)
+        def writes(x: Either[L, R]): JsValue = x match {
+          case Left(x)  => Json.obj("left" -> lf.writes(x))
+          case Right(x) => rf.writes(x)
+        }
 
-      left.orElse(right)
-    }
+        def reads(json: JsValue): JsResult[Either[L, R]] = {
+          def left = for {left <- (json \ "left").validate[L]} yield Left(left)
+
+          def right = for {right <- json.validate[R]} yield Right(right)
+
+          left.orElse(right)
+        }
+      }
   }
+
+  @deprecated(
+    "A Right can read back as a Left, see EitherFormatUnsafe. Opt into it explicitly, excluding this " +
+      "one from a wildcard import as `PlayJsonHelper.{eitherFormat => _, _}`, or move to " +
+      "DiscriminatedEitherFormat.eitherFormat, which labels both sides but writes a different document",
+    "1.4.0")
+  implicit def eitherFormat[L, R](implicit lf: Format[L], rf: Format[R]): Format[Either[L, R]] =
+    EitherFormatUnsafe.eitherFormat
 
   object DiscriminatedEitherFormat {
     def valueFromUnambiguousKey[A](key: String, otherKey: String)(implicit ra: Reads[A]): Reads[A] =

--- a/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
+++ b/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
@@ -90,6 +90,16 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     Json.fromJson[FiniteDuration](JsString("Inf")) shouldBe a[JsError]
   }
 
+  test("finiteDurationFormat reports a number larger than a Long") {
+    errorMessagesOf(Json.fromJson[FiniteDuration](JsNumber(BigDecimal(Long.MaxValue) + 1))) should
+      include("error.expected.long")
+  }
+
+  test("finiteDurationFormat reports a number of milliseconds it cannot hold") {
+    errorMessagesOf(Json.fromJson[FiniteDuration](JsNumber(BigDecimal(Long.MaxValue)))) should
+      include("Duration is limited")
+  }
+
   test("finiteDurationFormat reports a fractional number") {
     errorMessagesOf(Json.fromJson[FiniteDuration](JsNumber(BigDecimal("1.5")))) should include("error.expected.long")
   }
@@ -108,6 +118,16 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
 
   test("instantFormat reads a number as epoch milliseconds") {
     Json.fromJson[Instant](JsNumber(1785492930123L)) shouldEqual JsSuccess(Instant.ofEpochMilli(1785492930123L))
+  }
+
+  test("instantFormat reports a number larger than a Long") {
+    errorMessagesOf(Json.fromJson[Instant](JsNumber(BigDecimal(Long.MaxValue) + 1))) should
+      include("error.expected.long")
+  }
+
+  test("instantFormat reads the largest number of milliseconds a Long holds") {
+    Json.fromJson[Instant](JsNumber(BigDecimal(Long.MaxValue))) shouldEqual
+      JsSuccess(Instant.ofEpochMilli(Long.MaxValue))
   }
 
   test("instantFormat reports a string it cannot parse") {

--- a/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
+++ b/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
@@ -32,6 +32,14 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     Json.fromJson[Either[String, Int]](json) shouldEqual JsSuccess(value)
   }
 
+  test("eitherFormat turns a Right that writes a left field into a Left") {
+    val value: Either[String, Map[String, String]] = Right(Map("left" -> "1"))
+    val json = Json.toJson(value)
+    json shouldEqual Json.obj("left" -> "1")
+    Json.fromJson[Either[String, Map[String, String]]](json) shouldEqual
+      JsSuccess(Left("1"): Either[String, Map[String, String]])
+  }
+
   test("unitFormat") {
     val value = ()
     val json = Json.toJson(value)
@@ -70,6 +78,10 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     Json.fromJson[FiniteDuration](JsString("garbage")) shouldBe a[JsError]
   }
 
+  test("finiteDurationFormat reports a bad string as a string, not as a missing number") {
+    errorMessagesOf(Json.fromJson[FiniteDuration](JsString("garbage"))) should include("garbage")
+  }
+
   test("finiteDurationFormat reports a duration that is not finite") {
     Json.fromJson[FiniteDuration](JsString("Inf")) shouldBe a[JsError]
   }
@@ -94,6 +106,10 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     Json.fromJson[Instant](JsString("garbage")) shouldBe a[JsError]
   }
 
+  test("instantFormat reports a bad string as a string, not as a missing number") {
+    errorMessagesOf(Json.fromJson[Instant](JsString("garbage"))) should include("garbage")
+  }
+
   test("localTimeFormat round-trips") {
     val value = LocalTime.of(10, 15, 30)
     val json = Json.toJson(value)
@@ -103,6 +119,11 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
 
   test("localTimeFormat reports a string it cannot parse") {
     Json.fromJson[LocalTime](JsString("garbage")) shouldBe a[JsError]
+  }
+
+  private def errorMessagesOf(result: JsResult[Any]): String = result match {
+    case JsError(errors) => errors.flatMap { case (_, invalid) => invalid.flatMap(_.messages) }.mkString(", ")
+    case JsSuccess(value, _) => s"read successfully as $value"
   }
 
   case object ConstObject

--- a/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
+++ b/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
@@ -6,6 +6,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
+import java.time.{Instant, LocalTime}
+import scala.concurrent.duration._
+
 class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
 
   test("nelFormat") {
@@ -50,6 +53,56 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     val json = Json.obj("nestedData" -> Json.obj("value" -> 123))
     format.writes(data) shouldEqual json
     format.reads(json) shouldEqual JsSuccess(data)
+  }
+
+  test("finiteDurationFormat round-trips a duration") {
+    val value = 1.minute
+    val json = Json.toJson(value)
+    json shouldEqual JsString("1 minute")
+    Json.fromJson[FiniteDuration](json) shouldEqual JsSuccess(value)
+  }
+
+  test("finiteDurationFormat reads a number as milliseconds") {
+    Json.fromJson[FiniteDuration](JsNumber(1500)) shouldEqual JsSuccess(1500.millis)
+  }
+
+  test("finiteDurationFormat reports a string it cannot parse") {
+    Json.fromJson[FiniteDuration](JsString("garbage")) shouldBe a[JsError]
+  }
+
+  test("finiteDurationFormat reports a duration that is not finite") {
+    Json.fromJson[FiniteDuration](JsString("Inf")) shouldBe a[JsError]
+  }
+
+  test("instantFormat round-trips, truncating to milliseconds") {
+    val value = Instant.parse("2026-08-03T10:15:30.123456Z")
+    val json = Json.toJson(value)
+    json shouldEqual JsString("2026-08-03T10:15:30.123Z")
+    Json.fromJson[Instant](json) shouldEqual JsSuccess(Instant.parse("2026-08-03T10:15:30.123Z"))
+  }
+
+  test("instantFormat reads an ISO-8601 instant") {
+    Json.fromJson[Instant](JsString("2026-08-03T10:15:30Z")) shouldEqual
+      JsSuccess(Instant.parse("2026-08-03T10:15:30Z"))
+  }
+
+  test("instantFormat reads a number as epoch milliseconds") {
+    Json.fromJson[Instant](JsNumber(1785492930123L)) shouldEqual JsSuccess(Instant.ofEpochMilli(1785492930123L))
+  }
+
+  test("instantFormat reports a string it cannot parse") {
+    Json.fromJson[Instant](JsString("garbage")) shouldBe a[JsError]
+  }
+
+  test("localTimeFormat round-trips") {
+    val value = LocalTime.of(10, 15, 30)
+    val json = Json.toJson(value)
+    json shouldEqual JsString("10:15:30")
+    Json.fromJson[LocalTime](json) shouldEqual JsSuccess(value)
+  }
+
+  test("localTimeFormat reports a string it cannot parse") {
+    Json.fromJson[LocalTime](JsString("garbage")) shouldBe a[JsError]
   }
 
   case object ConstObject

--- a/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
+++ b/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
@@ -18,26 +18,30 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     Json.fromJson[Nel[Int]](json) shouldEqual JsSuccess(value)
   }
 
+  // the format is opted into rather than taken from the wildcard import above, which is how callers
+  // reach it now that the implicit in `PlayJsonHelper` is deprecated
+  private val stringOrInt: Format[Either[String, Int]] = EitherFormatUnsafe.eitherFormat
+  private val stringOrMap: Format[Either[String, Map[String, String]]] = EitherFormatUnsafe.eitherFormat
+
   test("eitherFormat left") {
     val value: Either[String, Int] = Left("1")
-    val json = Json.toJson(value)
+    val json = stringOrInt.writes(value)
     json shouldEqual Json.obj("left" -> "1")
-    Json.fromJson[Either[String, Int]](json) shouldEqual JsSuccess(value)
+    stringOrInt.reads(json) shouldEqual JsSuccess(value)
   }
 
   test("eitherFormat right") {
     val value: Either[String, Int] = Right(2)
-    val json = Json.toJson(value)
+    val json = stringOrInt.writes(value)
     json shouldEqual JsNumber(2)
-    Json.fromJson[Either[String, Int]](json) shouldEqual JsSuccess(value)
+    stringOrInt.reads(json) shouldEqual JsSuccess(value)
   }
 
   test("eitherFormat turns a Right that writes a left field into a Left") {
     val value: Either[String, Map[String, String]] = Right(Map("left" -> "1"))
-    val json = Json.toJson(value)
+    val json = stringOrMap.writes(value)
     json shouldEqual Json.obj("left" -> "1")
-    Json.fromJson[Either[String, Map[String, String]]](json) shouldEqual
-      JsSuccess(Left("1"): Either[String, Map[String, String]])
+    stringOrMap.reads(json) shouldEqual JsSuccess(Left("1"): Either[String, Map[String, String]])
   }
 
   test("unitFormat") {

--- a/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
+++ b/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
@@ -86,6 +86,10 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     Json.fromJson[FiniteDuration](JsString("Inf")) shouldBe a[JsError]
   }
 
+  test("finiteDurationFormat reports a fractional number") {
+    errorMessagesOf(Json.fromJson[FiniteDuration](JsNumber(BigDecimal("1.5")))) should include("error.expected.long")
+  }
+
   test("instantFormat round-trips, truncating to milliseconds") {
     val value = Instant.parse("2026-08-03T10:15:30.123456Z")
     val json = Json.toJson(value)
@@ -110,6 +114,10 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     errorMessagesOf(Json.fromJson[Instant](JsString("garbage"))) should include("garbage")
   }
 
+  test("instantFormat reports a fractional number") {
+    errorMessagesOf(Json.fromJson[Instant](JsNumber(BigDecimal("1.5")))) should include("error.expected.long")
+  }
+
   test("localTimeFormat round-trips") {
     val value = LocalTime.of(10, 15, 30)
     val json = Json.toJson(value)
@@ -119,6 +127,10 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
 
   test("localTimeFormat reports a string it cannot parse") {
     Json.fromJson[LocalTime](JsString("garbage")) shouldBe a[JsError]
+  }
+
+  test("localTimeFormat reports input that is not a string") {
+    errorMessagesOf(Json.fromJson[LocalTime](JsNumber(1))) should include("error.expected.jsstring")
   }
 
   private def errorMessagesOf(result: JsResult[Any]): String = result match {

--- a/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
+++ b/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
@@ -90,6 +90,27 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
     Json.fromJson[FiniteDuration](JsString("Inf")) shouldBe a[JsError]
   }
 
+  // `-1 minute` is written in the plural where `1 minute` is not, which is what Duration.toString does
+  test("finiteDurationFormat round-trips a negative duration") {
+    val value = -1.minute
+    val json = Json.toJson(value)
+    json shouldEqual JsString("-1 minutes")
+    Json.fromJson[FiniteDuration](json) shouldEqual JsSuccess(value)
+  }
+
+  test("finiteDurationFormat reads a negative number as milliseconds") {
+    Json.fromJson[FiniteDuration](JsNumber(-1500)) shouldEqual JsSuccess(-1500.millis)
+  }
+
+  test("finiteDurationFormat reports a duration that is negative infinity") {
+    Json.fromJson[FiniteDuration](JsString("MinusInf")) shouldBe a[JsError]
+  }
+
+  test("finiteDurationFormat reports a negative number of milliseconds it cannot hold") {
+    errorMessagesOf(Json.fromJson[FiniteDuration](JsNumber(BigDecimal(Long.MinValue)))) should
+      include("Duration is limited")
+  }
+
   test("finiteDurationFormat reports a number larger than a Long") {
     errorMessagesOf(Json.fromJson[FiniteDuration](JsNumber(BigDecimal(Long.MaxValue) + 1))) should
       include("error.expected.long")
@@ -118,6 +139,41 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
 
   test("instantFormat reads a number as epoch milliseconds") {
     Json.fromJson[Instant](JsNumber(1785492930123L)) shouldEqual JsSuccess(Instant.ofEpochMilli(1785492930123L))
+  }
+
+  test("instantFormat round-trips a moment before 1970") {
+    val value = Instant.ofEpochMilli(-1)
+    val json = Json.toJson(value)
+    json shouldEqual JsString("1969-12-31T23:59:59.999Z")
+    Json.fromJson[Instant](json) shouldEqual JsSuccess(value)
+  }
+
+  test("instantFormat writes years from 1 onwards") {
+    val written = Seq(
+      "0001-01-01T00:00:00.000Z",
+      "0500-06-15T12:00:00.000Z",
+      "1969-12-31T23:59:59.999Z",
+      "1970-01-01T00:00:00.000Z",
+      "2026-08-03T10:15:30.123Z",
+      "+292278994-08-17T07:12:55.807Z",
+    )
+
+    written.foreach { text =>
+      val instant = Json.fromJson[Instant](JsString(text)).getOrElse(fail(s"could not read $text"))
+      withClue(s"$text: ") { Json.toJson(instant) shouldEqual JsString(text) }
+    }
+  }
+
+  test("instantFormat round-trips a moment before year 1") {
+    val value = Instant.parse("-0100-01-01T00:00:00Z")
+    val json = Json.toJson(value)
+    json shouldEqual JsString("-0100-01-01T00:00:00.000Z")
+    Json.fromJson[Instant](json) shouldEqual JsSuccess(value)
+  }
+
+  test("instantFormat reads a year written without an era as that year") {
+    Json.fromJson[Instant](JsString("0101-01-01T00:00:00.000Z")) shouldEqual
+      JsSuccess(Instant.parse("0101-01-01T00:00:00Z"))
   }
 
   test("instantFormat reports a number larger than a Long") {


### PR DESCRIPTION
The Instant, LocalTime and FiniteDuration reads let parse failures escape as exceptions: a DateTimeParseException for an unparseable timestamp or time, a NumberFormatException for a bad duration, and a ClassCastException for a duration that parses but is not finite, such as "Inf". Callers that handle JsError correctly still got an exception from untrusted input, and the failure surfaced far from the field that caused it.

All three now report the failure as a JsError naming the value that could not be read.

For reviewers:

- The three formats had no tests at all. They now have round-trips, both numeric fallbacks, and a case per failure mode.
- InstantFormat writes milliseconds and drops anything finer. That is unchanged, and now has a test and a scaladoc note, because the fix touches the same format and the truncation must not shift.
- Errors previously blamed the wrong thing. readStr orElse readNum discards the string branch's error, so a malformed string was reported as a missing number. The reads now pick the branch from the JSON shape, so the message describes the actual problem. Accepted inputs are unchanged.
- The implicit eitherFormat writes a Left as {"left": ...} and a Right bare, so a Right that writes an object with a readable left field is silently read back as a Left. This branch documents it and pins it with a test rather than changing it, since any disambiguation would alter stored bytes. DiscriminatedEitherFormat.eitherFormat remains the opt-in alternative.