### PR TITLE
Build play-json-tools with Scala 2.13.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ import Dependencies.*
 
 import scala.collection.Seq
 
-val Scala213 = "2.13.18"
+val Scala213       = "2.13.18"
+val Scala213Pinned = "2.13.16"
 val Scala3   = "3.3.8"
 
 val commonSettings = Seq(
@@ -77,6 +78,7 @@ lazy val `play-json-generic` = crossProject(JVMPlatform, JSPlatform)
 lazy val `play-json-tools` = project
   .settings(
     commonSettings,
+    scalaVersion := Scala213Pinned,
     libraryDependencies ++= Seq(
       playJson,
       nel,


### PR DESCRIPTION
Pins the play-json-tools module to Scala 2.13.16, leaving the other modules on 2.13.18. dictionaries depends on play-json-tools and cannot move past 2.13.16 yet because of a checksum incompatibility affecting games, so a 2.13.18 build is unconsumable there. Only this module is downgraded; play-json-generic, play-json-jsoniter and play-json-circe stay on 2.13.18 because their dependencies require scala-library 2.13.18 (SIP-51). All modules green on 2.13.16, 2.13.18 and 3.3.8.