### PR TITLE
Build all modules with Scala 2.13.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - 2.13.18
+          - 2.13.16
           - 3.3.8
 
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,7 @@ import Dependencies.*
 
 import scala.collection.Seq
 
-val Scala213       = "2.13.18"
-val Scala213Pinned = "2.13.16"
+val Scala213 = "2.13.16"
 val Scala3   = "3.3.8"
 
 val commonSettings = Seq(
@@ -64,6 +63,7 @@ lazy val `play-json-generic` = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .settings(
     commonSettings,
+    allowUnsafeScalaLibUpgrade := true,
     libraryDependencies ++= (Seq(
       playJson,
       scalaTest % Test
@@ -78,7 +78,6 @@ lazy val `play-json-generic` = crossProject(JVMPlatform, JSPlatform)
 lazy val `play-json-tools` = project
   .settings(
     commonSettings,
-    scalaVersion := Scala213Pinned,
     libraryDependencies ++= Seq(
       playJson,
       nel,
@@ -94,6 +93,7 @@ lazy val `play-json-jsoniter` = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .settings(
     commonSettings,
+    allowUnsafeScalaLibUpgrade := true,
     libraryDependencies ++= (Seq(
       playJson,
       jsoniter,
@@ -110,6 +110,7 @@ lazy val `play-json-jsoniter` = crossProject(JVMPlatform, JSPlatform)
 lazy val `play-json-circe` = project
   .settings(
     commonSettings,
+    allowUnsafeScalaLibUpgrade := true,
     libraryDependencies ++= Seq(
       playJson,
       circe.core,


### PR DESCRIPTION
Moves the whole build to Scala 2.13.16 instead of pinning only play-json-tools, which put two full 2.13 versions in the cross matrix and made +publish upload play-json-tools_2.13 twice, failing the v1.3.1 release. play-json-generic, play-json-jsoniter and play-json-circe need allowUnsafeScalaLibUpgrade because their dependencies require scala-library 2.13.18. CI matrix follows. All modules green on 2.13.16 and 3.3.8.