### PR TITLE
Pin scala-library to 2.13.16 for Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.13.16" }
+]


### PR DESCRIPTION
This build is deliberately on Scala 2.13.16 so that consumers pinned there can use it: dictionaries cannot move to 2.13.18 because of a checksum incompatibility affecting games. Without this pin Steward would bump the build back to 2.13.18 and silently break those consumers, with no signal in their repos. Scala 3 updates are unaffected, since those track scala3-library.