### PR TITLE
Json depth limits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val benchmark = project
   .enablePlugins(JmhPlugin)
   .settings(
     commonSettings,
+    allowUnsafeScalaLibUpgrade := true,
     publish / skip := true,
     crossScalaVersions := Seq(Scala213),
     Jmh / sourceDirectory := (Test / sourceDirectory).value,

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
@@ -9,7 +9,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{
 }
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import play.api.libs.json.{JsArray, JsNumber, JsObject, JsValue, Json, JsonConfig, JsonValueCodecJsValue}
+import play.api.libs.json._
 
 import java.nio.charset.StandardCharsets
 import scala.util.{Success, Try}
@@ -23,7 +23,7 @@ import scala.util.{Success, Try}
 class JsonDepthSpec extends AnyFunSuite with Matchers {
 
   /** Jackson's default, and therefore what play-json reads. */
-  private val PlayJsonNestingLimit = 1000
+  private val playJsonNestingLimit = 1000
 
   private def nestedObjectBytes(depth: Int): Array[Byte] =
     asBytes(("{\"n\":" * depth) + "1" + ("}" * depth))
@@ -65,15 +65,15 @@ class JsonDepthSpec extends AnyFunSuite with Matchers {
   }
 
   test("reading accepts the same nesting play-json accepts") {
-    PlayJsonJsoniter.deserialize(nestedObjectBytes(PlayJsonNestingLimit)).isSuccess shouldBe true
+    PlayJsonJsoniter.deserialize(nestedObjectBytes(playJsonNestingLimit)).isSuccess shouldBe true
   }
 
   test("reading refuses the nesting play-json refuses") {
-    PlayJsonJsoniter.deserialize(nestedObjectBytes(PlayJsonNestingLimit + 1)).isFailure shouldBe true
+    PlayJsonJsoniter.deserialize(nestedObjectBytes(playJsonNestingLimit + 1)).isFailure shouldBe true
   }
 
   test("reading agrees with play-json around the limit") {
-    val outcomes = (PlayJsonNestingLimit - 2 to PlayJsonNestingLimit + 2).map { depth =>
+    val outcomes = (playJsonNestingLimit - 2 to playJsonNestingLimit + 2).map { depth =>
       val json = nestedObjectBytes(depth)
       val playJsonReads = Try(Json.parse(json)).isSuccess
       depth -> (PlayJsonJsoniter.deserialize(json).isSuccess, playJsonReads)
@@ -83,11 +83,11 @@ class JsonDepthSpec extends AnyFunSuite with Matchers {
   }
 
   test("writing a value nested deeper than it could be read is refused") {
-    a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(nestedValue(PlayJsonNestingLimit + 1))
+    a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(nestedValue(playJsonNestingLimit + 1))
   }
 
   test("the default limit is the one play-json reads") {
-    JsonValueCodecJsValue.DefaultMaxNestingDepth shouldEqual PlayJsonNestingLimit
+    JsonValueCodecJsValue.DefaultMaxNestingDepth shouldEqual playJsonNestingLimit
   }
 
   test("a codec given a smaller limit holds both directions to it") {
@@ -117,15 +117,15 @@ class JsonDepthSpec extends AnyFunSuite with Matchers {
   test("an empty container at the limit counts as a level, as it does for play-json") {
     Seq("{}", "[]").foreach { innermost =>
       // the innermost container brings the total to the depth in the clue
-      val atLimit = wrapping(PlayJsonNestingLimit - 1, innermost)
-      val pastLimit = wrapping(PlayJsonNestingLimit, innermost)
+      val atLimit = wrapping(playJsonNestingLimit - 1, innermost)
+      val pastLimit = wrapping(playJsonNestingLimit, innermost)
 
-      withClue(s"$innermost at depth $PlayJsonNestingLimit: ") {
+      withClue(s"$innermost at depth $playJsonNestingLimit: ") {
         PlayJsonJsoniter.deserialize(atLimit).isSuccess shouldBe true
         Try(Json.parse(atLimit)).isSuccess shouldBe true
       }
 
-      withClue(s"$innermost at depth ${PlayJsonNestingLimit + 1}: ") {
+      withClue(s"$innermost at depth ${playJsonNestingLimit + 1}: ") {
         PlayJsonJsoniter.deserialize(pastLimit).isFailure shouldBe true
         Try(Json.parse(pastLimit)).isSuccess shouldBe false
       }
@@ -133,15 +133,15 @@ class JsonDepthSpec extends AnyFunSuite with Matchers {
   }
 
   test("writing a value whose innermost container is empty counts it as a level") {
-    val atLimit = nestedAround(JsObject.empty, PlayJsonNestingLimit - 1)
-    val pastLimit = nestedAround(JsObject.empty, PlayJsonNestingLimit)
+    val atLimit = nestedAround(JsObject.empty, playJsonNestingLimit - 1)
+    val pastLimit = nestedAround(JsObject.empty, playJsonNestingLimit)
 
     PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(atLimit)) shouldEqual Success(atLimit)
     a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(pastLimit)
   }
 
   test("arrays and objects count towards the same limit") {
-    val mixed = (1 to PlayJsonNestingLimit / 2).foldLeft[JsValue](JsNumber(1)) { (inner, _) =>
+    val mixed = (1 to playJsonNestingLimit / 2).foldLeft[JsValue](JsNumber(1)) { (inner, _) =>
       JsArray(Seq(JsObject(Seq("n" -> inner))))
     }
 

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
@@ -33,9 +33,23 @@ class JsonDepthSpec extends AnyFunSuite with Matchers {
 
   private def asBytes(text: String): Array[Byte] = text.getBytes(StandardCharsets.UTF_8)
 
+  private def wrapping(layers: Int, innermost: String): Array[Byte] =
+    asBytes(("{\"n\":" * layers) + innermost + ("}" * layers))
+
+  private def nestedAround(innermost: JsValue, layers: Int): JsValue = (1 to layers).foldLeft(innermost) { (inner, _) =>
+    JsObject(Seq("n" -> inner))
+  }
+
   private def nestedValue(depth: Int): JsValue = (1 to depth).foldLeft[JsValue](JsNumber(1)) { (inner, _) =>
     JsObject(Seq("n" -> inner))
   }
+
+  private def codecOf(maxNestingDepth: Int): Either[String, JsonValueCodec[JsValue]] =
+    JsonValueCodecJsValue.of(
+      JsonConfig.settings.bigDecimalParseConfig,
+      JsonConfig.settings.bigDecimalSerializerConfig,
+      maxNestingDepth
+    )
 
   test("a shallowly nested document round-trips") {
     val value = nestedValue(64)
@@ -78,17 +92,52 @@ class JsonDepthSpec extends AnyFunSuite with Matchers {
 
   test("a codec given a smaller limit holds both directions to it") {
     val shallow = 3
-    implicit val codec: JsonValueCodec[JsValue] = JsonValueCodecJsValue(
-      JsonConfig.settings.bigDecimalParseConfig,
-      JsonConfig.settings.bigDecimalSerializerConfig,
-      shallow
-    )
+    implicit val codec: JsonValueCodec[JsValue] =
+      codecOf(shallow).getOrElse(fail(s"could not build a codec bounded at $shallow"))
 
     readFromArray[JsValue](nestedObjectBytes(shallow)) shouldEqual nestedValue(shallow)
     a[JsonReaderException] should be thrownBy readFromArray[JsValue](nestedObjectBytes(shallow + 1))
 
     writeToArray[JsValue](nestedValue(shallow)) shouldEqual nestedObjectBytes(shallow)
     a[JsonWriterException] should be thrownBy writeToArray[JsValue](nestedValue(shallow + 1))
+  }
+
+  test("a limit that refuses everything is reported rather than built") {
+    Seq(0, -1, Int.MinValue).foreach { limit =>
+      withClue(s"limit $limit: ") {
+        codecOf(limit).left.map(_.contains(limit.toString)) shouldEqual Left(true)
+      }
+    }
+  }
+
+  test("the default limit builds a codec") {
+    codecOf(JsonValueCodecJsValue.DefaultMaxNestingDepth).isRight shouldBe true
+  }
+
+  test("an empty container at the limit counts as a level, as it does for play-json") {
+    Seq("{}", "[]").foreach { innermost =>
+      // the innermost container brings the total to the depth in the clue
+      val atLimit = wrapping(PlayJsonNestingLimit - 1, innermost)
+      val pastLimit = wrapping(PlayJsonNestingLimit, innermost)
+
+      withClue(s"$innermost at depth $PlayJsonNestingLimit: ") {
+        PlayJsonJsoniter.deserialize(atLimit).isSuccess shouldBe true
+        Try(Json.parse(atLimit)).isSuccess shouldBe true
+      }
+
+      withClue(s"$innermost at depth ${PlayJsonNestingLimit + 1}: ") {
+        PlayJsonJsoniter.deserialize(pastLimit).isFailure shouldBe true
+        Try(Json.parse(pastLimit)).isSuccess shouldBe false
+      }
+    }
+  }
+
+  test("writing a value whose innermost container is empty counts it as a level") {
+    val atLimit = nestedAround(JsObject.empty, PlayJsonNestingLimit - 1)
+    val pastLimit = nestedAround(JsObject.empty, PlayJsonNestingLimit)
+
+    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(atLimit)) shouldEqual Success(atLimit)
+    a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(pastLimit)
   }
 
   test("arrays and objects count towards the same limit") {

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
@@ -1,0 +1,68 @@
+package com.evolution.playjson.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriterException
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsNumber, JsObject, JsValue, Json}
+
+import java.nio.charset.StandardCharsets
+import scala.util.{Success, Try}
+
+/** Nesting is bounded in both directions, at the depth play-json reads. Reading further diverges
+  * from play-json and eventually exhausts the stack. Writing further produces a document play-json
+  * cannot read, which is the one place this codec is deliberately stricter than play-json.
+  *
+  * JVM only on purpose: the limit play-json enforces is Jackson's, and Jackson is the JVM backend.
+  */
+class JsonDepthSpec extends AnyFunSuite with Matchers {
+
+  /** Jackson's default, and therefore what play-json reads. */
+  private val PlayJsonNestingLimit = 1000
+
+  private def nestedObjectBytes(depth: Int): Array[Byte] =
+    asBytes(("{\"n\":" * depth) + "1" + ("}" * depth))
+
+  private def nestedArrayBytes(depth: Int): Array[Byte] =
+    asBytes(("[" * depth) + "1" + ("]" * depth))
+
+  private def asBytes(text: String): Array[Byte] = text.getBytes(StandardCharsets.UTF_8)
+
+  private def nestedValue(depth: Int): JsValue = (1 to depth).foldLeft[JsValue](JsNumber(1)) { (inner, _) =>
+    JsObject(Seq("n" -> inner))
+  }
+
+  test("a shallowly nested document round-trips") {
+    val value = nestedValue(64)
+    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(value)) shouldEqual Success(value)
+  }
+
+  test("reading an object nested past the stack depth fails") {
+    PlayJsonJsoniter.deserialize(nestedObjectBytes(100000)).isFailure shouldBe true
+  }
+
+  test("reading an array nested past the stack depth fails") {
+    PlayJsonJsoniter.deserialize(nestedArrayBytes(100000)).isFailure shouldBe true
+  }
+
+  test("reading accepts the same nesting play-json accepts") {
+    PlayJsonJsoniter.deserialize(nestedObjectBytes(PlayJsonNestingLimit)).isSuccess shouldBe true
+  }
+
+  test("reading refuses the nesting play-json refuses") {
+    PlayJsonJsoniter.deserialize(nestedObjectBytes(PlayJsonNestingLimit + 1)).isFailure shouldBe true
+  }
+
+  test("reading agrees with play-json around the limit") {
+    val outcomes = (PlayJsonNestingLimit - 2 to PlayJsonNestingLimit + 2).map { depth =>
+      val json = nestedObjectBytes(depth)
+      val playJsonReads = Try(Json.parse(json)).isSuccess
+      depth -> (PlayJsonJsoniter.deserialize(json).isSuccess, playJsonReads)
+    }
+
+    outcomes.filter { case (_, (jsoniter, playJson)) => jsoniter != playJson } shouldBe empty
+  }
+
+  test("writing a value nested deeper than it could be read is refused") {
+    a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(nestedValue(PlayJsonNestingLimit + 1))
+  }
+}

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
@@ -1,9 +1,15 @@
 package com.evolution.playjson.jsoniter
 
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriterException
+import com.github.plokhotnyuk.jsoniter_scala.core.{
+  JsonReaderException,
+  JsonValueCodec,
+  JsonWriterException,
+  readFromArray,
+  writeToArray
+}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import play.api.libs.json.{JsNumber, JsObject, JsValue, Json}
+import play.api.libs.json.{JsArray, JsNumber, JsObject, JsValue, Json, JsonConfig, JsonValueCodecJsValue}
 
 import java.nio.charset.StandardCharsets
 import scala.util.{Success, Try}
@@ -64,5 +70,33 @@ class JsonDepthSpec extends AnyFunSuite with Matchers {
 
   test("writing a value nested deeper than it could be read is refused") {
     a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(nestedValue(PlayJsonNestingLimit + 1))
+  }
+
+  test("the default limit is the one play-json reads") {
+    JsonValueCodecJsValue.DefaultMaxNestingDepth shouldEqual PlayJsonNestingLimit
+  }
+
+  test("a codec given a smaller limit holds both directions to it") {
+    val shallow = 3
+    implicit val codec: JsonValueCodec[JsValue] = JsonValueCodecJsValue(
+      JsonConfig.settings.bigDecimalParseConfig,
+      JsonConfig.settings.bigDecimalSerializerConfig,
+      shallow
+    )
+
+    readFromArray[JsValue](nestedObjectBytes(shallow)) shouldEqual nestedValue(shallow)
+    a[JsonReaderException] should be thrownBy readFromArray[JsValue](nestedObjectBytes(shallow + 1))
+
+    writeToArray[JsValue](nestedValue(shallow)) shouldEqual nestedObjectBytes(shallow)
+    a[JsonWriterException] should be thrownBy writeToArray[JsValue](nestedValue(shallow + 1))
+  }
+
+  test("arrays and objects count towards the same limit") {
+    val mixed = (1 to PlayJsonNestingLimit / 2).foldLeft[JsValue](JsNumber(1)) { (inner, _) =>
+      JsArray(Seq(JsObject(Seq("n" -> inner))))
+    }
+
+    PlayJsonJsoniter.deserialize(PlayJsonJsoniter.serialize(mixed)) shouldEqual Success(mixed)
+    a[JsonWriterException] should be thrownBy PlayJsonJsoniter.serialize(JsArray(Seq(mixed)))
   }
 }

--- a/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
+++ b/play-json-jsoniter/jvm/src/test/scala/com/evolution/playjson/jsoniter/JsonDepthSpec.scala
@@ -102,12 +102,18 @@ class JsonDepthSpec extends AnyFunSuite with Matchers {
     a[JsonWriterException] should be thrownBy writeToArray[JsValue](nestedValue(shallow + 1))
   }
 
-  test("a limit that refuses everything is reported rather than built") {
-    Seq(0, -1, Int.MinValue).foreach { limit =>
+  test("a limit outside the accepted range is reported rather than built") {
+    val tooDeep = JsonValueCodecJsValue.MaxAllowedNestingDepth + 1
+
+    Seq(0, -1, Int.MinValue, tooDeep, Int.MaxValue).foreach { limit =>
       withClue(s"limit $limit: ") {
         codecOf(limit).left.map(_.contains(limit.toString)) shouldEqual Left(true)
       }
     }
+  }
+
+  test("the largest accepted limit builds a codec") {
+    codecOf(JsonValueCodecJsValue.MaxAllowedNestingDepth).isRight shouldBe true
   }
 
   test("the default limit builds a codec") {

--- a/play-json-jsoniter/shared/src/main/scala/com/evolution/playjson/jsoniter/PlayJsonJsoniter.scala
+++ b/play-json-jsoniter/shared/src/main/scala/com/evolution/playjson/jsoniter/PlayJsonJsoniter.scala
@@ -44,26 +44,30 @@ object PlayJsonJsoniter {
   implicit val zonedDateTimeFormat: Format[ZonedDateTime] =
     Formats.smallAsciiStringFormat[ZonedDateTime]("ZonedDateTime", _.readZonedDateTime(_), _.writeVal(_))
 
-  /** Throws `JsonWriterException` for a number that could not be read back, see
-    * [[play.api.libs.json.JsonValueCodecJsValue]].
+  /** Throws `JsonWriterException` for a number that could not be read back, and for nesting deeper
+    * than play-json can read, see [[play.api.libs.json.JsonValueCodecJsValue]].
     */
   def serialize(payload: JsValue): Array[Byte] =
     writeToArray(payload)
 
-  /** Throws `JsonWriterException` for a number that could not be read back, see [[serialize]]. */
+  /** Throws `JsonWriterException` for a number that could not be read back, and for nesting deeper
+    * than play-json can read, see [[serialize]].
+    */
   def serializeToStr(payload: JsValue): String =
     writeToString(payload)
 
-  /** Throws `JsonWriterException` for a number that could not be read back, see [[serialize]].
-    * The failure is raised where the number is reached, so `bbuf` is left holding the part of the
-    * document written up to that point.
+  /** Throws `JsonWriterException` for a number that could not be read back, and for nesting deeper
+    * than play-json can read, see [[serialize]]. The failure is raised where the number or the
+    * nesting is reached, so `bbuf` is left holding the part of the document written up to that
+    * point.
     */
   def serializeToBuffer(payload: JsValue, bbuf: ByteBuffer): Unit =
     writeToByteBuffer(payload, bbuf)
 
-  /** Throws `JsonWriterException` for a number that could not be read back, see [[serialize]].
-    * The failure is raised where the number is reached, and the writer flushes as its buffer
-    * fills, so `out` may already have received an incomplete document.
+  /** Throws `JsonWriterException` for a number that could not be read back, and for nesting deeper
+    * than play-json can read, see [[serialize]]. The failure is raised where the number or the
+    * nesting is reached, and the writer flushes as its buffer fills, so `out` may already have
+    * received an incomplete document.
     */
   def serializeToOutput(payload: JsValue, out: OutputStream): Unit =
     writeToStream(payload, out)

--- a/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
+++ b/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
@@ -41,9 +41,20 @@ object JsonValueCodecJsValue {
       bigDecimalParseSettings: BigDecimalParseConfig,
       bigDecimalSerializerSettings: BigDecimalSerializerConfig
   ): JsonValueCodec[JsValue] =
-    apply(bigDecimalParseSettings, bigDecimalSerializerSettings, DefaultMaxNestingDepth)
+    unsafe(bigDecimalParseSettings, bigDecimalSerializerSettings, DefaultMaxNestingDepth)
 
-  def apply(
+  def of(
+      bigDecimalParseSettings: BigDecimalParseConfig,
+      bigDecimalSerializerSettings: BigDecimalSerializerConfig,
+      maxNestingDepth: Int
+  ): Either[String, JsonValueCodec[JsValue]] =
+    if (maxNestingDepth > 0) {
+      Right(unsafe(bigDecimalParseSettings, bigDecimalSerializerSettings, maxNestingDepth))
+    } else {
+      Left(s"maxNestingDepth must be positive, but was $maxNestingDepth")
+    }
+
+  private def unsafe(
       bigDecimalParseSettings: BigDecimalParseConfig,
       bigDecimalSerializerSettings: BigDecimalSerializerConfig,
       maxNestingDepth: Int

--- a/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
+++ b/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
@@ -24,6 +24,11 @@ object JsonValueCodecJsValue {
   private val FastPathSmallestValue = BigDecimal("1e-6")
   private val FastPathLargestValue = BigDecimal("1e18")
 
+  /** Jackson's default, and therefore the depth play-json reads. Matching it keeps both backends
+    * accepting the same documents, and keeps this codec from writing one play-json cannot read.
+    */
+  val DefaultMaxNestingDepth: Int = 1000
+
   @deprecated(
     "Reading settings are given here, writing settings are taken from the global " +
       "JsonConfig.settings. Pass both explicitly instead.",
@@ -36,8 +41,17 @@ object JsonValueCodecJsValue {
       bigDecimalParseSettings: BigDecimalParseConfig,
       bigDecimalSerializerSettings: BigDecimalSerializerConfig
   ): JsonValueCodec[JsValue] =
+    apply(bigDecimalParseSettings, bigDecimalSerializerSettings, DefaultMaxNestingDepth)
+
+  def apply(
+      bigDecimalParseSettings: BigDecimalParseConfig,
+      bigDecimalSerializerSettings: BigDecimalSerializerConfig,
+      maxNestingDepth: Int
+  ): JsonValueCodec[JsValue] =
     new JsonValueCodec[JsValue] {
-      def decodeValue(in: JsonReader, default: JsValue): JsValue = {
+      def decodeValue(in: JsonReader, default: JsValue): JsValue = decodeValue(in, default, 0)
+
+      private def decodeValue(in: JsonReader, default: JsValue, depth: Int): JsValue = {
         val b = in.nextToken()
         if (b == '"') {
           in.rollbackToken()
@@ -55,6 +69,7 @@ object JsonValueCodecJsValue {
             bigDecimalParseSettings.digitsLimit
           ))
         } else if (b == '[') {
+          val level = nextLevel(in, depth)
           if (in.isNextToken(']')) JsArray.empty
           else {
             in.rollbackToken()
@@ -62,7 +77,7 @@ object JsonValueCodecJsValue {
             var i = 0
             while ({
               if (i == vs.length) vs = java.util.Arrays.copyOf(vs, i << 1)
-              vs(i) = decodeValue(in, default)
+              vs(i) = decodeValue(in, default, level)
               i += 1
               in.isNextToken(',')
             }) ()
@@ -73,12 +88,13 @@ object JsonValueCodecJsValue {
             else in.arrayEndOrCommaError()
           }
         } else if (b == '{') {
+          val level = nextLevel(in, depth)
           if (in.isNextToken('}')) JsObject.empty
           else {
             in.rollbackToken()
             val kvs = new java.util.LinkedHashMap[String, JsValue](8)
             while ({
-              kvs.put(in.readKeyAsString(), decodeValue(in, default))
+              kvs.put(in.readKeyAsString(), decodeValue(in, default, level))
               in.isNextToken(',')
             }) ()
             if (in.isCurrentToken('}')) new JsObject({
@@ -90,7 +106,9 @@ object JsonValueCodecJsValue {
         } else in.readNullOrError(default, "expected JSON value")
       }
 
-      def encodeValue(jsValue: JsValue, out: JsonWriter): Unit =
+      def encodeValue(jsValue: JsValue, out: JsonWriter): Unit = encodeValue(jsValue, out, 0)
+
+      private def encodeValue(jsValue: JsValue, out: JsonWriter, depth: Int): Unit =
         jsValue match {
           case s: JsString =>
             out.writeVal(s.value)
@@ -99,19 +117,33 @@ object JsonValueCodecJsValue {
           case n: JsNumber =>
             encodeBigDecimal(n.value, out)
           case a: JsArray =>
+            val level = nextLevel(out, depth)
             out.writeArrayStart()
-            a.value.foreach(encodeValue(_, out))
+            a.value.foreach(encodeValue(_, out, level))
             out.writeArrayEnd()
           case o: JsObject =>
+            val level = nextLevel(out, depth)
             out.writeObjectStart()
             o.underlying.foreach { kv =>
               out.writeKey(kv._1)
-              encodeValue(kv._2, out)
+              encodeValue(kv._2, out, level)
             }
             out.writeObjectEnd()
           case _ =>
             out.writeNull()
         }
+
+      private def nextLevel(in: JsonReader, depth: Int): Int = {
+        val level = depth + 1
+        if (level > maxNestingDepth) in.decodeError(s"depth of nesting exceeds $maxNestingDepth")
+        level
+      }
+
+      private def nextLevel(out: JsonWriter, depth: Int): Int = {
+        val level = depth + 1
+        if (level > maxNestingDepth) out.encodeError(s"depth of nesting exceeds $maxNestingDepth")
+        level
+      }
 
       /** Whether the configured settings are wide enough for [[needsNoNormalization]] to imply
         * play-json parity. Computed once: the reasoning there is about magnitudes and digit counts,

--- a/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
+++ b/play-json-jsoniter/shared/src/main/scala/play/api/libs/json/JsonValueCodecJsValue.scala
@@ -29,6 +29,9 @@ object JsonValueCodecJsValue {
     */
   val DefaultMaxNestingDepth: Int = 1000
 
+  /** The largest depth [[of]] accepts. */
+  val MaxAllowedNestingDepth: Int = 10000
+
   @deprecated(
     "Reading settings are given here, writing settings are taken from the global " +
       "JsonConfig.settings. Pass both explicitly instead.",
@@ -43,15 +46,22 @@ object JsonValueCodecJsValue {
   ): JsonValueCodec[JsValue] =
     unsafe(bigDecimalParseSettings, bigDecimalSerializerSettings, DefaultMaxNestingDepth)
 
+  /** A codec bounded at `maxNestingDepth`, or the reason that depth cannot be used.
+    *
+    * @param maxNestingDepth
+    *   levels of arrays and objects to accept, from 1 to [[MaxAllowedNestingDepth]]. Both directions
+    *   recurse once per level, so the depth a thread survives is bounded by its stack: about 2000
+    *   levels on 1 MB (the JVM default for the main thread on 64-bit), about 10000 on 2 MB.
+    */
   def of(
       bigDecimalParseSettings: BigDecimalParseConfig,
       bigDecimalSerializerSettings: BigDecimalSerializerConfig,
       maxNestingDepth: Int
   ): Either[String, JsonValueCodec[JsValue]] =
-    if (maxNestingDepth > 0) {
+    if (maxNestingDepth > 0 && maxNestingDepth <= MaxAllowedNestingDepth) {
       Right(unsafe(bigDecimalParseSettings, bigDecimalSerializerSettings, maxNestingDepth))
     } else {
-      Left(s"maxNestingDepth must be positive, but was $maxNestingDepth")
+      Left(s"maxNestingDepth must be between 1 and $MaxAllowedNestingDepth, but was $maxNestingDepth")
     }
 
   private def unsafe(


### PR DESCRIPTION
Read and wrote arbitrarily deep JSON. Reasons for a change:

1. Running out of stack is not a failure a caller can handle. The codec recurses once per level of nesting, so a deep enough document exhausts the stack.
2. The depth that breaks it was a property of the thread, not the document. The frame budget is whatever stack the calling thread was given. The same document read on two threads succeeded on one and overflowed on the other. A document that passes in one service could fail in the service that reads it. A fixed limit makes the outcome depend on the input alone.
3. Writing deeper than play-json reads produced documents nobody could consume. At depth 1001 the
codec wrote clean bytes that its own reader accepted and `Json.parse` refused.

Note: play-json's own writer has no depth limit either, so `Json.toBytes` produces documents `Json.parse`
refuses - its own output, unchanged. This codec is now stricter than play-json there: it refuses to
write past the depth play-json can read. The only documents that refusal costs are ones no play-json
reader could have consumed, and the error arrives at the writer instead of in whatever service
parses it later. Callers who genuinely need deeper output can build a codec with a higher bound.

Performance cost is negligible. The recorded `post 1.4` benchmark figures still stand ± a few %.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable nesting-depth limits for JSON value encoding and decoding.
  * Introduced a default maximum depth of 1,000, with supported limits up to 10,000.
  * JSON processing now reports clear failures when configured nesting limits are exceeded.

* **Bug Fixes**
  * Improved handling of deeply nested arrays and objects to prevent stack-depth failures.

* **Documentation**
  * Clarified that serialization may fail when nesting exceeds supported limits and that partial output may already have been written.

* **Tests**
  * Added coverage for depth limits, boundary values, custom configurations, and invalid settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->