### PR TITLE
Deprecate the millisecond-precision Instant format

### DIFF
--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -46,32 +46,46 @@ object PlayJsonHelper {
     def writes(o: FiniteDuration): JsString = JsString(o.toCoarsest.toString)
   }
 
-  implicit val InstantFormat: Format[Instant] = new Format[Instant] {
+  /** Writes three digits of fraction, so anything finer than a millisecond is dropped. Reads any
+    * fraction, so documents written with full precision elsewhere can still be read.
+    */
+  object MillisPrecisionInstant {
 
-    // `uuuu` is the year itself, where `yyyy` is the year within the era: with no era in the pattern,
-    // `yyyy` wrote an instant before year 1 as the matching year AD, so 100 BC came back as 101 AD.
-    // The two agree for every instant from year 1 onwards, so only those are written differently
-    private val millisFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
-    private val isoFormatter = DateTimeFormatter.ISO_INSTANT
+    implicit val instantFormat: Format[Instant] = new Format[Instant] {
 
-    def reads(json: JsValue): JsResult[Instant] = {
-      def parse(string: String) = Try(millisFormatter.parse(string))
-        .recover { case _: DateTimeParseException => isoFormatter.parse(string) }
-        .map(Instant.from)
+      // `uuuu` is the year itself, where `yyyy` is the year within the era: with no era in the pattern,
+      // `yyyy` wrote an instant before year 1 as the matching year AD, so 100 BC came back as 101 AD.
+      // The two agree for every instant from year 1 onwards, so only those are written differently
+      private val millisFormatter =
+        DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+      private val isoFormatter = DateTimeFormatter.ISO_INSTANT
 
-      // see the note on FiniteDurationFormat.reads for why the shape is matched first
-      json match {
-        case JsString(string) => parse(string) match {
-            case Success(instant) => JsSuccess(instant)
-            case Failure(error)   => JsError(error.toString)
-          }
-        case _ => for { millis <- json.validate[Long] } yield Instant.ofEpochMilli(millis)
+      def reads(json: JsValue): JsResult[Instant] = {
+        def parse(string: String) = Try(millisFormatter.parse(string))
+          .recover { case _: DateTimeParseException => isoFormatter.parse(string) }
+          .map(Instant.from)
+
+        // see the note on FiniteDurationFormat.reads for why the shape is matched first
+        json match {
+          case JsString(string) => parse(string) match {
+              case Success(instant) => JsSuccess(instant)
+              case Failure(error)   => JsError(error.toString)
+            }
+          case _ => for { millis <- json.validate[Long] } yield Instant.ofEpochMilli(millis)
+        }
       }
-    }
 
-    /** Writes milliseconds, so any finer precision the instant carries is dropped. */
-    def writes(o: Instant): JsValue = JsString(millisFormatter.format(o))
+      /** Writes milliseconds, so any finer precision the instant carries is dropped. */
+      def writes(o: Instant): JsValue = JsString(millisFormatter.format(o))
+    }
   }
+
+  @deprecated(
+    "Deprecated due to reduced precision on the wire. Use MillisPrecisionInstant.instantFormat " +
+      "explicitly if a millisecond is precise enough for your data",
+    "1.4.0"
+  )
+  implicit val InstantFormat: Format[Instant] = MillisPrecisionInstant.instantFormat
 
   implicit val LocalTimeFormat: Format[LocalTime] = new Format[LocalTime] {
 

--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -61,9 +61,10 @@ object PlayJsonHelper {
       private val isoFormatter = DateTimeFormatter.ISO_INSTANT
 
       def reads(json: JsValue): JsResult[Instant] = {
-        def parse(string: String) = Try(millisFormatter.parse(string))
-          .recover { case _: DateTimeParseException => isoFormatter.parse(string) }
-          .map(Instant.from)
+        def parse(string: String) =
+          Try(millisFormatter.parse(string))
+            .recover { case _: DateTimeParseException => isoFormatter.parse(string) }
+            .map(Instant.from)
 
         // see the note on FiniteDurationFormat.reads for why the shape is matched first
         json match {

--- a/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
+++ b/play-json-tools/src/main/scala/com/evolution/playjson/tools/PlayJsonHelper.scala
@@ -71,7 +71,7 @@ object PlayJsonHelper {
               case Success(instant) => JsSuccess(instant)
               case Failure(error)   => JsError(error.toString)
             }
-          case _ => for { millis <- json.validate[Long] } yield Instant.ofEpochMilli(millis)
+          case _ => json.validate[Long].map(Instant.ofEpochMilli(_))
         }
       }
 

--- a/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
+++ b/play-json-tools/src/test/scala/com/evolution/playjson/tools/PlayJsonHelperSpec.scala
@@ -1,12 +1,14 @@
 package com.evolution.playjson.tools
 
-import com.evolution.playjson.tools.PlayJsonHelper._
+import com.evolution.playjson.tools.PlayJsonHelper.MillisPrecisionInstant.instantFormat
+import com.evolution.playjson.tools.PlayJsonHelper.{InstantFormat => _, _}
 import com.evolutiongaming.nel.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
 import java.time.{Instant, LocalTime}
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
@@ -137,6 +139,12 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
       JsSuccess(Instant.parse("2026-08-03T10:15:30Z"))
   }
 
+  // reading is wider than writing, so a document written with full precision elsewhere still reads
+  test("instantFormat reads a finer fraction than it writes") {
+    Json.fromJson[Instant](JsString("2026-08-03T10:15:30.123456789Z")) shouldEqual
+      JsSuccess(Instant.parse("2026-08-03T10:15:30.123456789Z"))
+  }
+
   test("instantFormat reads a number as epoch milliseconds") {
     Json.fromJson[Instant](JsNumber(1785492930123L)) shouldEqual JsSuccess(Instant.ofEpochMilli(1785492930123L))
   }
@@ -196,6 +204,14 @@ class PlayJsonHelperSpec extends AnyFunSuite with Matchers {
 
   test("instantFormat reports a fractional number") {
     errorMessagesOf(Json.fromJson[Instant](JsNumber(BigDecimal("1.5")))) should include("error.expected.long")
+  }
+
+  @nowarn("cat=deprecation")
+  private val deprecatedInstantFormat: Format[Instant] = PlayJsonHelper.InstantFormat
+
+  // the deprecated name delegates rather than holding a copy, so the two cannot drift apart
+  test("the deprecated InstantFormat is MillisPrecisionInstant.instantFormat") {
+    deprecatedInstantFormat should be theSameInstanceAs instantFormat
   }
 
   test("localTimeFormat round-trips") {


### PR DESCRIPTION
`PlayJsonHelper.InstantFormat` writes three digits of fraction, so an `Instant` of finer precision
does not come back as itself. Nothing at the call site says so. A wildcard import of `PlayJsonHelper`
picks the format up silently, and the loss only shows up in serialised data.

The format moves to `MillisPrecisionInstant`, where the name states which precision is kept, and
`InstantFormat` is deprecated and delegates to it. Callers who are content with milliseconds opt in
by name. Callers who are not now get a compiler warning where they previously got silent truncation.

Reading is unchanged and stays wider than writing: any fraction is accepted, so a document written
with full precision elsewhere still reads. That is what makes a later move off this format possible.

No behaviour changes. The deprecated name is the same instance, which a test holds, so the two
cannot drift apart while both exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public formatter for `Instant` values.
  - Instant timestamps now accept nanosecond-precision input while continuing to be written with millisecond precision.
  - Improved support for numeric epoch-millisecond values and dates before year 1 AD.

- **Deprecation**
  - The existing `InstantFormat` formatter remains available for compatibility and now delegates to the new formatter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->